### PR TITLE
Add cache-backed document content streaming

### DIFF
--- a/gebo.microservices.architecture.parent/gebo.architecture.documents.cache.microservice.client/pom.xml
+++ b/gebo.microservices.architecture.parent/gebo.architecture.documents.cache.microservice.client/pom.xml
@@ -28,6 +28,21 @@
 			<artifactId>gebo.architecture.documents.cache</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!-- IGDocumentContentStreamer + DocumentContentStreamerException: implemented
+		     by DocumentContentStreamerWithCacheRestClient, which streams a document
+		     through the chunker's local cache instead of its owning content handler. -->
+		<dependency>
+			<groupId>ai.gebo.architecture</groupId>
+			<artifactId>gebo.architecture.documents.access</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<!-- GeboMicroserviceUrlResolver + its autoconfigured bean: resolves the
+		     chunker microservice's base url. -->
+		<dependency>
+			<groupId>ai.gebo.microservices.architecture</groupId>
+			<artifactId>gebo.microservices.topology</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		<!-- @ConfigurationProperties / @ConditionalOnMissingBean support. -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/gebo.microservices.architecture.parent/gebo.architecture.documents.cache.microservice.client/src/main/java/ai/gebo/architecture/documents/cache/client/DocumentContentStreamerWithCacheRestClient.java
+++ b/gebo.microservices.architecture.parent/gebo.architecture.documents.cache.microservice.client/src/main/java/ai/gebo/architecture/documents/cache/client/DocumentContentStreamerWithCacheRestClient.java
@@ -1,0 +1,152 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.architecture.documents.cache.client;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import ai.gebo.architecture.documents.access.DocumentContentStreamerException;
+import ai.gebo.architecture.documents.access.IGDocumentContentStreamer;
+import ai.gebo.architecture.documents.access.StreamingPurpose;
+import ai.gebo.architecture.search.model.SearchResult;
+import ai.gebo.knlowledgebase.model.contents.GDocumentReference;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.model.base.IGComponentOriginatedDocument;
+import ai.gebo.model.base.TypedInputStream;
+
+/**
+ * {@link IGDocumentContentStreamer} that streams a document's content
+ * <b>through the chunker microservice's document cache</b>, by calling its
+ * {@code DocumentContentStreamerWithCacheController}.
+ *
+ * <p>
+ * Unlike
+ * {@code ai.gebo.architecture.microservices.documents.access.GMicroserviceDocumentContentStreamerClient},
+ * which goes straight to the content-handler microservice owning each document,
+ * this client always targets a single service — the chunker — resolved by
+ * {@link GeboMicroserviceUrlResolver#baseUrlForMicroserviceId(String)} from the
+ * configured microservice id ({@code chunker_gebo_ai} by default). The chunker
+ * fetches the document from its owning content handler once, keeps the bytes in
+ * its local file cache and serves them from there on subsequent calls, so a
+ * consumer (e.g. brain.gebo.ai) that reads the same document repeatedly pays the
+ * content-handler transfer only once.
+ *
+ * <p>
+ * {@code streamDocumentReference} is called for a {@link GDocumentReference},
+ * {@code streamSearchResult} for a {@link SearchResult}; the octet-stream
+ * response body, its content type and the {@code X-Gebo-Content-Extension}
+ * header are returned as a {@link TypedInputStream}.
+ */
+public class DocumentContentStreamerWithCacheRestClient implements IGDocumentContentStreamer {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DocumentContentStreamerWithCacheRestClient.class);
+
+	static final String CONTROLLER_PATH = "/api/DocumentContentStreamerWithCacheController/";
+	static final String STREAM_DOCUMENT_REFERENCE = "streamDocumentReference";
+	static final String STREAM_SEARCH_RESULT = "streamSearchResult";
+	static final String EXTENSION_HEADER = "X-Gebo-Content-Extension";
+
+	private final WebClient webClient;
+	private final GeboMicroserviceUrlResolver urlResolver;
+	private final String microserviceId;
+
+	/**
+	 * @param webClient the WebClient carrying the api-key / extra headers; its base
+	 *            url is irrelevant because every call targets an absolute uri
+	 * @param urlResolver resolves the caching microservice's base url
+	 * @param microserviceId id of the microservice hosting the cache controller
+	 *            (the chunker)
+	 */
+	public DocumentContentStreamerWithCacheRestClient(WebClient webClient, GeboMicroserviceUrlResolver urlResolver,
+			String microserviceId) {
+		this.webClient = webClient;
+		this.urlResolver = urlResolver;
+		this.microserviceId = microserviceId;
+	}
+
+	@Override
+	public TypedInputStream streamContent(StreamingPurpose purpose, IGComponentOriginatedDocument document)
+			throws DocumentContentStreamerException, IOException {
+		if (document == null) {
+			throw new DocumentContentStreamerException("Cannot stream a null document");
+		}
+		String baseUrl = urlResolver.baseUrlForMicroserviceId(microserviceId)
+				.orElseThrow(() -> new DocumentContentStreamerException("No microservice base url for '" + microserviceId
+						+ "', the document cache cannot be reached (document " + document.getCode() + ")"));
+
+		String endpoint;
+		Object requestBody;
+		if (document instanceof GDocumentReference reference) {
+			endpoint = STREAM_DOCUMENT_REFERENCE;
+			GDocumentReferenceStreamRequest request = new GDocumentReferenceStreamRequest();
+			request.streamingPurpose = purpose;
+			request.reference = reference;
+			requestBody = request;
+		} else if (document instanceof SearchResult searchResult) {
+			endpoint = STREAM_SEARCH_RESULT;
+			SearchResultStreamRequest request = new SearchResultStreamRequest();
+			request.streamingPurpose = purpose;
+			request.reference = searchResult;
+			requestBody = request;
+		} else {
+			throw new DocumentContentStreamerException(
+					"Unsupported document type for streaming: " + document.getClass().getName());
+		}
+
+		URI uri = URI.create(baseUrl + CONTROLLER_PATH + endpoint);
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("REST streamContent(" + document.getCode() + ") -> " + uri);
+		}
+		try {
+			ResponseEntity<byte[]> response = webClient.post().uri(uri).contentType(MediaType.APPLICATION_JSON)
+					.accept(MediaType.APPLICATION_OCTET_STREAM).bodyValue(requestBody).retrieve().toEntity(byte[].class)
+					.block();
+			if (response == null || response.getStatusCode() == HttpStatus.NO_CONTENT || response.getBody() == null) {
+				return null;
+			}
+			MediaType contentType = response.getHeaders().getContentType();
+			String extension = response.getHeaders().getFirst(EXTENSION_HEADER);
+			return TypedInputStream.of(new ByteArrayInputStream(response.getBody()),
+					contentType != null ? contentType.toString() : null, extension);
+		} catch (WebClientResponseException ex) {
+			throw new DocumentContentStreamerException(
+					"Remote cached streamContent failed: " + ex.getStatusCode() + " " + ex.getResponseBodyAsString(), ex);
+		} catch (RuntimeException ex) {
+			throw new DocumentContentStreamerException("Remote cached streamContent failed", ex);
+		}
+	}
+
+	/**
+	 * Request body for {@code streamDocumentReference}, mirroring
+	 * {@code DocumentContentStreamerWithCacheController.GDocumentReferenceStreamRequest}.
+	 */
+	public static class GDocumentReferenceStreamRequest {
+		public StreamingPurpose streamingPurpose;
+		public GDocumentReference reference;
+	}
+
+	/**
+	 * Request body for {@code streamSearchResult}, mirroring
+	 * {@code DocumentContentStreamerWithCacheController.SearchResultStreamRequest}.
+	 */
+	public static class SearchResultStreamRequest {
+		public StreamingPurpose streamingPurpose;
+		public SearchResult reference;
+	}
+}

--- a/gebo.microservices.architecture.parent/gebo.architecture.documents.cache.microservice.client/src/main/java/ai/gebo/architecture/documents/cache/client/config/DocumentsCacheClientProperties.java
+++ b/gebo.microservices.architecture.parent/gebo.architecture.documents.cache.microservice.client/src/main/java/ai/gebo/architecture/documents/cache/client/config/DocumentsCacheClientProperties.java
@@ -40,6 +40,15 @@ public class DocumentsCacheClientProperties {
 	private String baseUrl = "http://localhost:8084";
 
 	/**
+	 * Id of the microservice hosting the documents-cache controllers (the chunker).
+	 * Used by {@code DocumentContentStreamerWithCacheRestClient} to resolve the
+	 * target base url through the {@code GeboMicroserviceUrlResolver} instead of
+	 * {@link #baseUrl}, so the call follows the deployment's addressing strategy
+	 * (load balancer / gateway / direct).
+	 */
+	private String microserviceId = "chunker_gebo_ai";
+
+	/**
 	 * Optional API key sent on every request under {@link #apiKeyHeader}. When
 	 * {@code null}/blank no api-key header is added.
 	 */
@@ -67,6 +76,14 @@ public class DocumentsCacheClientProperties {
 
 	public void setBaseUrl(String baseUrl) {
 		this.baseUrl = baseUrl;
+	}
+
+	public String getMicroserviceId() {
+		return microserviceId;
+	}
+
+	public void setMicroserviceId(String microserviceId) {
+		this.microserviceId = microserviceId;
 	}
 
 	public String getApiKey() {

--- a/gebo.microservices.architecture.parent/gebo.architecture.documents.cache.microservice.client/src/main/java/ai/gebo/architecture/documents/cache/client/config/DocumentsCacheMicroserviceClientConfiguration.java
+++ b/gebo.microservices.architecture.parent/gebo.architecture.documents.cache.microservice.client/src/main/java/ai/gebo/architecture/documents/cache/client/config/DocumentsCacheMicroserviceClientConfiguration.java
@@ -17,10 +17,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import ai.gebo.architecture.documents.access.IGDocumentContentStreamer;
+import ai.gebo.architecture.documents.cache.client.DocumentContentStreamerWithCacheRestClient;
 import ai.gebo.architecture.documents.cache.client.DocumentsCacheServiceRestClient;
 import ai.gebo.architecture.documents.cache.client.DocumentsChunkServiceRestClient;
 import ai.gebo.architecture.documents.cache.service.IDocumentsCacheService;
 import ai.gebo.architecture.documents.cache.service.IDocumentsChunkService;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
 
 /**
  * Wires the documents-cache microservice REST client.
@@ -28,8 +31,10 @@ import ai.gebo.architecture.documents.cache.service.IDocumentsChunkService;
  * <p>
  * Builds a dedicated {@link WebClient} pointed at the configured chunker base
  * URL and pre-loaded with the api-key header and any extra headers, then
- * publishes {@link IDocumentsCacheService} and {@link IDocumentsChunkService}
- * beans backed by it. Both service beans are
+ * publishes {@link IDocumentsCacheService}, {@link IDocumentsChunkService} and
+ * {@link IGDocumentContentStreamer} beans backed by it (the streamer targets the
+ * chunker resolved by the {@link GeboMicroserviceUrlResolver} rather than the
+ * configured base url). The service beans are
  * {@link ConditionalOnMissingBean @ConditionalOnMissingBean}, so a service that
  * already hosts the real implementation (e.g. the chunker microservice itself)
  * keeps its local beans while a consumer that does not (e.g. brain.gebo.ai)
@@ -74,5 +79,23 @@ public class DocumentsCacheMicroserviceClientConfiguration {
 	public IDocumentsChunkService documentsChunkServiceRestClient(
 			@Qualifier(WEB_CLIENT_BEAN) WebClient documentsCacheClientWebClient) {
 		return new DocumentsChunkServiceRestClient(documentsCacheClientWebClient);
+	}
+
+	/**
+	 * {@link IGDocumentContentStreamer} served by the chunker's document cache: the
+	 * content is fetched from its owning content handler once by the chunker, cached
+	 * there and streamed back from that local copy afterwards. The chunker is
+	 * addressed through the {@link GeboMicroserviceUrlResolver} (from
+	 * {@link DocumentsCacheClientProperties#getMicroserviceId()}), not through the
+	 * client's {@code base-url}, so the call honours the deployment's addressing
+	 * strategy.
+	 */
+	@Bean
+	@ConditionalOnMissingBean(IGDocumentContentStreamer.class)
+	public IGDocumentContentStreamer documentContentStreamerWithCacheRestClient(
+			@Qualifier(WEB_CLIENT_BEAN) WebClient documentsCacheClientWebClient,
+			GeboMicroserviceUrlResolver urlResolver, DocumentsCacheClientProperties properties) {
+		return new DocumentContentStreamerWithCacheRestClient(documentsCacheClientWebClient, urlResolver,
+				properties.getMicroserviceId());
 	}
 }

--- a/gebo.microservices.architecture.parent/gebo.architecture.documents.cache.microservice.controller/src/main/java/ai/gebo/architecture/documents/cache/controllers/DocumentContentStreamerWithCacheController.java
+++ b/gebo.microservices.architecture.parent/gebo.architecture.documents.cache.microservice.controller/src/main/java/ai/gebo/architecture/documents/cache/controllers/DocumentContentStreamerWithCacheController.java
@@ -1,0 +1,117 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.architecture.documents.cache.controllers;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import ai.gebo.architecture.documents.access.IGDocumentContentStreamer;
+import ai.gebo.architecture.documents.access.StreamingPurpose;
+import ai.gebo.architecture.documents.cache.service.DocumentCacheAccessException;
+import ai.gebo.architecture.documents.cache.service.impl.DocumentsCacheServiceImpl;
+import ai.gebo.architecture.search.model.SearchResult;
+import ai.gebo.knlowledgebase.model.contents.GDocumentReference;
+import ai.gebo.model.base.IGComponentOriginatedDocument;
+import ai.gebo.model.base.TypedInputStream;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * Cache-backed twin of the content-handler
+ * {@code DocumentContentStreamerController}: it exposes the very same
+ * {@code streamDocumentReference} / {@code streamSearchResult} endpoints, but
+ * serves the bytes through {@link DocumentsCacheServiceImpl} instead of reading
+ * them from the owning content system on every call.
+ *
+ * <p>
+ * The cache service resolves the document with the chunker's own
+ * {@link IGDocumentContentStreamer} (the microservices one, which fetches from
+ * the content-handler microservice owning the document), stores the payload in
+ * the chunker's local file cache and streams it back. Subsequent requests for
+ * the same document are served from that local copy until the source's
+ * modification date moves past it, so callers that repeatedly need a remote
+ * document's content pay the cross-service transfer only once.
+ */
+@RestController
+@RequestMapping("api/DocumentContentStreamerWithCacheController")
+public class DocumentContentStreamerWithCacheController {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DocumentContentStreamerWithCacheController.class);
+
+	static final String EXTENSION_HEADER = "X-Gebo-Content-Extension";
+
+	private final DocumentsCacheServiceImpl documentsCacheService;
+
+	public DocumentContentStreamerWithCacheController(DocumentsCacheServiceImpl documentsCacheService) {
+		this.documentsCacheService = documentsCacheService;
+	}
+
+	@Data
+	public static class GDocumentReferenceStreamRequest {
+		@NotNull
+		public StreamingPurpose streamingPurpose;
+		@NotNull
+		public GDocumentReference reference;
+	}
+
+	@Data
+	public static class SearchResultStreamRequest {
+		@NotNull
+		public StreamingPurpose streamingPurpose;
+		@NotNull
+		public SearchResult reference;
+	}
+
+	@PostMapping(value = "streamDocumentReference", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+	public ResponseEntity<Resource> streamDocumentReference(@RequestBody GDocumentReferenceStreamRequest document)
+			throws DocumentCacheAccessException, IOException {
+		return stream(document.streamingPurpose, document.reference);
+	}
+
+	@PostMapping(value = "streamSearchResult", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+	public ResponseEntity<Resource> streamSearchResult(@RequestBody SearchResultStreamRequest document)
+			throws DocumentCacheAccessException, IOException {
+		return stream(document.streamingPurpose, document.reference);
+	}
+
+	private ResponseEntity<Resource> stream(StreamingPurpose streamingPurpose, IGComponentOriginatedDocument reference)
+			throws DocumentCacheAccessException, IOException {
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("REST streamContentWithCache(" + (reference != null ? reference.getCode() : null) + ")");
+		}
+		TypedInputStream tis = documentsCacheService.streamDocument(streamingPurpose, reference);
+		if (tis == null || tis.getInputStream() == null) {
+			return ResponseEntity.noContent().build();
+		}
+		MediaType contentType = MediaType.APPLICATION_OCTET_STREAM;
+		if (tis.getContentType() != null) {
+			try {
+				contentType = MediaType.parseMediaType(tis.getContentType());
+			} catch (Exception ex) {
+				LOGGER.warn("Unparseable content type '" + tis.getContentType() + "', falling back to octet-stream");
+			}
+		}
+		ResponseEntity.BodyBuilder builder = ResponseEntity.ok().contentType(contentType);
+		if (tis.getExtension() != null) {
+			builder.header(EXTENSION_HEADER, tis.getExtension());
+		}
+		return builder.body(new InputStreamResource(tis.getInputStream()));
+	}
+}


### PR DESCRIPTION
Expose DocumentContentStreamerWithCacheController on the chunker, serving the DocumentContentStreamerController endpoints through DocumentsCacheServiceImpl so a remote document is fetched from its content handler once and then served from the chunker's local cache.

Add DocumentContentStreamerWithCacheRestClient, an IGDocumentContentStreamer that calls that controller on the chunker microservice resolved via GeboMicroserviceUrlResolver (ai.gebo.documents.cache.client.microservice-id).