### PR TITLE
fix(heimdall): stop pulling llms.abstraction.layer onto lean microser…

### DIFF
--- a/gebo.architecture.parent/gebo.architecture.fastsetup.system/pom.xml
+++ b/gebo.architecture.parent/gebo.architecture.fastsetup.system/pom.xml
@@ -26,11 +26,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>ai.gebo.architecture</groupId>
-			<artifactId>gebo.architecture.chat.abstraction.layer</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>ai.gebo</groupId>
 			<artifactId>gebo.config</artifactId>
 			<version>${project.version}</version>

--- a/gebo.architecture.parent/gebo.architecture.fastsetup.system/src/main/java/ai/gebo/architecture/fastsetup/system/services/GeboFastInstallationSetupService.java
+++ b/gebo.architecture.parent/gebo.architecture.fastsetup.system/src/main/java/ai/gebo/architecture/fastsetup/system/services/GeboFastInstallationSetupService.java
@@ -21,7 +21,6 @@ import ai.gebo.architecture.fastsetup.system.model.FastInstallationSetupData;
 import ai.gebo.knlowledgebase.model.licence.GeboLicence;
 import ai.gebo.knlowledgebase.model.licence.GeboLicence.GeboLicenceType;
 import ai.gebo.knowledgebase.repositories.GeboLicenceRepository;
-import ai.gebo.llms.chat.abstraction.layer.services.IGChatProfileManagementService;
 import ai.gebo.model.GUserMessage;
 import ai.gebo.model.OperationStatus;
 import ai.gebo.security.config.GeboAISecurityConfig;
@@ -53,8 +52,6 @@ public class GeboFastInstallationSetupService {
 	IGUsersAdminService userAdminService;
 	@Autowired
 	IGPersistentObjectManager persistenceManager;
-	@Autowired
-	IGChatProfileManagementService chatProfileManagementService;
 
 	/**
 	 * Constructor for GeboFastInstallationSetupService.
@@ -125,7 +122,6 @@ public class GeboFastInstallationSetupService {
 			status.getMessages().clear();
 			status.getMessages().add(GUserMessage.successMessage("Admin user created !",
 					"Admin user " + data.getUsername() + " created successfully"));
-			this.chatProfileManagementService.getOrCreateDefaultChatProfile();
 		} catch (GeboCryptSecretException e) {
 			status.getMessages().add(GUserMessage.errorMessage("Problems in the crypting layer", e));
 		} catch (Throwable th) {

--- a/gebo.architecture.parent/gebo.architecture.fastsetup/pom.xml
+++ b/gebo.architecture.parent/gebo.architecture.fastsetup/pom.xml
@@ -21,11 +21,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>ai.gebo.architecture</groupId>
-			<artifactId>gebo.architecture.llms.abstraction.layer</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>ai.gebo.core</groupId>
 			<artifactId>gebo.knowledgebase.repositories</artifactId>
 			<version>${project.version}</version>
@@ -34,6 +29,13 @@
 			<groupId>ai.gebo</groupId>
 			<artifactId>gebo.config</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+		<!-- For @PreAuthorize on GeboAdvancedSetupStatusController. Previously came in
+		     transitively through gebo.architecture.llms.abstraction.layer. -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/gebo.architecture.parent/gebo.architecture.fastsetup/src/main/java/ai/gebo/architecture/fastsetup/services/GeboAdvancedSetupStatusService.java
+++ b/gebo.architecture.parent/gebo.architecture.fastsetup/src/main/java/ai/gebo/architecture/fastsetup/services/GeboAdvancedSetupStatusService.java
@@ -29,8 +29,6 @@ import ai.gebo.config.GeboConfig;
 import ai.gebo.config.model.MongoGeboInstallation;
 import ai.gebo.architecture.fastsetup.model.GeboAdvancedSetupStatus;
 import ai.gebo.knowledgebase.repositories.KnowledgeBaseRepository;
-import ai.gebo.llms.abstraction.layer.services.IGChatModelRuntimeConfigurationDao;
-import ai.gebo.llms.abstraction.layer.services.IGEmbeddingModelRuntimeConfigurationDao;
 
 /**
  * Service class providing methods to check the setup status for various components
@@ -46,12 +44,6 @@ public class GeboAdvancedSetupStatusService {
 	
 	@Autowired
 	GeboConfig geboConfig;
-	
-	@Autowired
-	IGChatModelRuntimeConfigurationDao chatModelsConfigDao;
-	
-	@Autowired
-	IGEmbeddingModelRuntimeConfigurationDao embeddingModelsConfigDao;
 	
 	@Autowired
 	IGRuntimeModuleComponentsDao runtimeModuleComponentsDao;
@@ -127,11 +119,6 @@ public class GeboAdvancedSetupStatusService {
 			status.firstSetupDone = geboInstallation.getFirstSetupDone() != null
 					&& geboInstallation.getFirstSetupDone();
 		}
-		
-		// Verify chat model and embedding model configurations
-		status.chatModelSetup = !chatModelsConfigDao.getConfigurations().isEmpty();
-		status.embeddedModelSetup = !embeddingModelsConfigDao.getConfigurations().isEmpty();
-		status.llmsSetup = status.chatModelSetup && status.embeddedModelSetup;
 		
 		List<GModuleUseInfo> modulesUserInfo = runtimeModuleComponentsDao.getModuleUseInfo();
 		

--- a/gebo.llms.parent/gebo.llms.setup/src/main/java/ai/gebo/llms/setup/services/DefaultChatProfileInitializationService.java
+++ b/gebo.llms.parent/gebo.llms.setup/src/main/java/ai/gebo/llms/setup/services/DefaultChatProfileInitializationService.java
@@ -1,0 +1,54 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.llms.setup.services;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import ai.gebo.llms.chat.abstraction.layer.services.IGChatProfileManagementService;
+
+/**
+ * Ensures the default chat profile exists on every service that carries the
+ * actual chat/RAG stack (monolith, brain), instead of being created inline by
+ * the fast-installation flow. {@link IGChatProfileManagementService#getOrCreateDefaultChatProfile()}
+ * is already get-or-create, so this is a no-op once the profile exists.
+ *
+ * Previously this call lived in
+ * {@code ai.gebo.architecture.fastsetup.system.services.GeboFastInstallationSetupService},
+ * which pulled {@code gebo.architecture.chat.abstraction.layer} (and transitively
+ * {@code gebo.architecture.llms.abstraction.layer} + {@code gebo.architecture.documents.cache})
+ * onto every consumer of {@code gebo.architecture.fastsetup.system} - including
+ * heimdall, which has no chat/RAG procedure of its own and crashed on an
+ * unrelated deep-search bean dragged in by that chain.
+ */
+@Component
+@Scope("singleton")
+public class DefaultChatProfileInitializationService {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DefaultChatProfileInitializationService.class);
+
+	private final IGChatProfileManagementService chatProfileManagementService;
+
+	public DefaultChatProfileInitializationService(IGChatProfileManagementService chatProfileManagementService) {
+		this.chatProfileManagementService = chatProfileManagementService;
+	}
+
+	@Scheduled(initialDelay = 20000)
+	public void onTick() {
+		try {
+			chatProfileManagementService.getOrCreateDefaultChatProfile();
+		} catch (Throwable th) {
+			LOGGER.error("Error ensuring the default chat profile exists", th);
+		}
+	}
+}


### PR DESCRIPTION
…vices

heimdall.gebo.ai crash-looped on boot with an UnsatisfiedDependencyException (missing IGVectorStoreConfigurationProvider, then missing IDocumentsChunkService) because two of its transitive dependencies dragged in unrelated LLM/RAG code that gebo.architecture.llms.abstraction.layer unconditionally component-scans:

- gebo.architecture.fastsetup depended on llms.abstraction.layer only to read two DAOs (IGChatModelRuntimeConfigurationDao/IGEmbeddingModelRuntimeConfigurationDao) for a getSetupStatus() method with zero callers - dropped the dependency and the dead fields.
- gebo.architecture.fastsetup.system depended on chat.abstraction.layer only to call IGChatProfileManagementService.getOrCreateDefaultChatProfile() right after admin-user creation. Moved that call into a new scheduled DefaultChatProfileInitializationService in gebo.llms.setup (already on the classpath of every service that actually has the chat/RAG stack - monolith via gebo.llms.starter, brain directly), mirroring the existing SystemInitializationLLMService one-shot-@Scheduled pattern in that module. fastsetup.system no longer needs chat.abstraction.layer at all.

heimdall's classpath no longer carries chat.abstraction.layer, llms.abstraction.layer, or documents.cache. Verified: full reactor build green, heimdall boots in ~8s and registers with Eureka.