### PR TITLE
feat(telemetry): wire OpenTelemetry/Micrometer observability across monolith and microservices

### DIFF
--- a/dockers/gebo.ai/docker-compose.yml
+++ b/dockers/gebo.ai/docker-compose.yml
@@ -177,6 +177,7 @@ services:
       GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
     volumes:
       - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
     ports:
       - "127.0.0.1:3000:3000"
     networks: [gebo-monolith-net]

--- a/dockers/gebo.ai/docker-compose.yml
+++ b/dockers/gebo.ai/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     volumes:
       # Bind mount a local directory instead of named volume
       - /home/gebo.ai/mongo:/data/db
+    networks: [gebo-monolith-net]
 
   # =======================
   # Qdrant
@@ -41,6 +42,7 @@ services:
     volumes:
       # Bind mount a local directory
       - /home/gebo.ai/qdrant:/qdrant/storage
+    networks: [gebo-monolith-net]
   neo4j:
     image: neo4j:5
     restart: always
@@ -65,6 +67,7 @@ services:
       - /home/gebo.ai/neo4j/logs:/logs
       - /home/gebo.ai/neo4j/plugins:/plugins
       - /home/gebo.ai/neo4j/import:/import
+    networks: [gebo-monolith-net]
   opensearch:
     image: opensearchproject/opensearch:latest
     container_name: opensearch
@@ -89,7 +92,8 @@ services:
     ports:
       - "9200:9200"
       - "9600:9600"
-    
+    networks: [gebo-monolith-net]
+
   # =======================
   # gebo.ai
   # =======================
@@ -118,6 +122,7 @@ services:
 
     environment:
       SPRING_PROFILES_ACTIVE: "prod"
+      MANAGEMENT_OTLP_TRACING_ENDPOINT: http://otel-collector:4318/v1/traces
       #Jvm settings
       JAVA_TOOL_OPTIONS: --enable-native-access=ALL-UNNAMED
         -Dsun.jnu.encoding=UTF-8
@@ -130,3 +135,58 @@ services:
         -Xmx4g
         -XX:MaxMetaspaceSize=512m
         --add-opens=java.base/java.nio.charset=ALL-UNNAMED
+    networks: [gebo-monolith-net]
+
+  # =======================
+  # Observability stack (metrics, traces, dashboards)
+  # =======================
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+    ports:
+      - "127.0.0.1:4318:4318"
+    networks: [gebo-monolith-net]
+
+  prometheus:
+    image: prom/prometheus
+    restart: unless-stopped
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "127.0.0.1:9090:9090"
+    networks: [gebo-monolith-net]
+
+  tempo:
+    image: grafana/tempo
+    restart: unless-stopped
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo.yaml:ro
+      - tempo-data:/var/tempo
+    networks: [gebo-monolith-net]
+
+  grafana:
+    image: grafana/grafana
+    restart: unless-stopped
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+    volumes:
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "127.0.0.1:3000:3000"
+    networks: [gebo-monolith-net]
+
+volumes:
+  opensearch-data:
+  prometheus-data:
+  grafana-data:
+  tempo-data:
+
+networks:
+  gebo-monolith-net:
+    driver: bridge

--- a/dockers/gebo.ai/grafana/provisioning/dashboards/dashboards.yaml
+++ b/dockers/gebo.ai/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: Gebo default dashboards
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/dockers/gebo.ai/grafana/provisioning/dashboards/gebo-overview.json
+++ b/dockers/gebo.ai/grafana/provisioning/dashboards/gebo-overview.json
@@ -1,0 +1,88 @@
+{
+  "title": "Gebo.ai Overview",
+  "uid": "gebo-overview",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Services up",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "up",
+          "legendFormat": "{{job}} - {{service}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "HTTP request rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count[1m])) by (service, uri)",
+          "legendFormat": "{{service}} {{uri}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP average request duration",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_sum[1m])) by (service) / sum(rate(http_server_requests_seconds_count[1m])) by (service)",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Message broker routing rate (per hop)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(rate(gebo_messaging_broker_routing_seconds_count[1m])) by (sourceModule, targetModule)",
+          "legendFormat": "{{sourceModule}} -> {{targetModule}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "JVM memory used",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(jvm_memory_used_bytes) by (service, area)",
+          "legendFormat": "{{service}} {{area}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/dockers/gebo.ai/grafana/provisioning/datasources/datasources.yaml
+++ b/dockers/gebo.ai/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,24 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: gebo-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Tempo
+    uid: gebo-tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      tracesToMetrics:
+        datasourceUid: gebo-prometheus
+      serviceMap:
+        datasourceUid: gebo-prometheus
+      nodeGraph:
+        enabled: true

--- a/dockers/gebo.ai/otel-collector-config.yaml
+++ b/dockers/gebo.ai/otel-collector-config.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch: {}
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo, debug]

--- a/dockers/gebo.ai/prometheus.yml
+++ b/dockers/gebo.ai/prometheus.yml
@@ -1,0 +1,12 @@
+# Scrape config for the Gebo.ai monolith deployment.
+# The monolith serves at the root context path, so actuator is at the
+# default /actuator/prometheus (no per-service context-path prefix, unlike
+# the microservices stack's prometheus.yml).
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: gebo-ai-monolith
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["gebo.ai:12999"]

--- a/dockers/gebo.ai/tempo-config.yaml
+++ b/dockers/gebo.ai/tempo-config.yaml
@@ -1,0 +1,26 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  trace_idle_period: 10s
+
+compactor:
+  compaction:
+    block_retention: 168h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal

--- a/dockers/gebo.microservices/docker-compose.yml
+++ b/dockers/gebo.microservices/docker-compose.yml
@@ -161,6 +161,7 @@ services:
       GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
     volumes:
       - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
     ports:
       - "127.0.0.1:3000:3000"     # Grafana UI (loopback only)
     networks: [gebo-net]

--- a/dockers/gebo.microservices/docker-compose.yml
+++ b/dockers/gebo.microservices/docker-compose.yml
@@ -44,6 +44,9 @@ x-microservice: &microservice
     EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka:13017/eureka/
     SPRING_CONFIG_ADDITIONAL_LOCATION: file:/opt/gebo.ai/config/
     JAVA_TOOL_OPTIONS: "-Xms256m -Xmx1g"
+    MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: health,prometheus,metrics
+    MANAGEMENT_TRACING_SAMPLING_PROBABILITY: "1.0"
+    MANAGEMENT_OTLP_TRACING_ENDPOINT: http://otel-collector:4318/v1/traces
   volumes:
     - ./config:/opt/gebo.ai/config:ro
     - /opt/gebo.ai/home          # per-container anonymous volume
@@ -118,6 +121,48 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka:13017/eureka/
     ports:
       - "13000:13000"
+    networks: [gebo-net]
+
+  # ---------------- Observability stack (metrics, traces, dashboards) --------
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+    ports:
+      - "127.0.0.1:4318:4318"     # OTLP HTTP (loopback only)
+    networks: [gebo-net]
+
+  prometheus:
+    image: prom/prometheus
+    restart: unless-stopped
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "127.0.0.1:9090:9090"     # Prometheus UI (loopback only)
+    networks: [gebo-net]
+
+  tempo:
+    image: grafana/tempo
+    restart: unless-stopped
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo.yaml:ro
+      - tempo-data:/var/tempo
+    networks: [gebo-net]
+
+  grafana:
+    image: grafana/grafana
+    restart: unless-stopped
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+    volumes:
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "127.0.0.1:3000:3000"     # Grafana UI (loopback only)
     networks: [gebo-net]
 
   # ---------------- Security service ----------------
@@ -251,6 +296,9 @@ volumes:
   qdrant-data:
   neo4j-data:
   opensearch-data:
+  prometheus-data:
+  grafana-data:
+  tempo-data:
 
 networks:
   gebo-net:

--- a/dockers/gebo.microservices/grafana/provisioning/dashboards/dashboards.yaml
+++ b/dockers/gebo.microservices/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: Gebo default dashboards
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/dockers/gebo.microservices/grafana/provisioning/dashboards/gebo-overview.json
+++ b/dockers/gebo.microservices/grafana/provisioning/dashboards/gebo-overview.json
@@ -1,0 +1,88 @@
+{
+  "title": "Gebo.ai Overview",
+  "uid": "gebo-overview",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Services up",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "up",
+          "legendFormat": "{{job}} - {{service}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "HTTP request rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count[1m])) by (service, uri)",
+          "legendFormat": "{{service}} {{uri}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP average request duration",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_sum[1m])) by (service) / sum(rate(http_server_requests_seconds_count[1m])) by (service)",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Message broker routing rate (per hop)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(rate(gebo_messaging_broker_routing_seconds_count[1m])) by (sourceModule, targetModule)",
+          "legendFormat": "{{sourceModule}} -> {{targetModule}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "JVM memory used",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(jvm_memory_used_bytes) by (service, area)",
+          "legendFormat": "{{service}} {{area}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/dockers/gebo.microservices/grafana/provisioning/datasources/datasources.yaml
+++ b/dockers/gebo.microservices/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,24 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: gebo-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Tempo
+    uid: gebo-tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      tracesToMetrics:
+        datasourceUid: gebo-prometheus
+      serviceMap:
+        datasourceUid: gebo-prometheus
+      nodeGraph:
+        enabled: true

--- a/dockers/gebo.microservices/otel-collector-config.yaml
+++ b/dockers/gebo.microservices/otel-collector-config.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch: {}
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo, debug]

--- a/dockers/gebo.microservices/prometheus.yml
+++ b/dockers/gebo.microservices/prometheus.yml
@@ -1,0 +1,63 @@
+# Scrape config for the Gebo.ai microservices stack.
+#
+# Every backend microservice registers spring.application.name = <name>_gebo_ai
+# and serves its own application.yml context-path /<name> (confirmed for brain
+# and tyr; assumed for the rest by the same convention - verify before relying
+# on this in production). Actuator therefore answers under that context path:
+# http://<service>:<port>/<name>/actuator/prometheus. __metrics_path__ is
+# computed per-target below since each service's prefix differs. The gateway
+# is the one exception - it is the edge service and serves at the root path.
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: gateway
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["gateway:13000"]
+
+  - job_name: gebo-microservices
+    relabel_configs:
+      - source_labels: [__meta_context_path]
+        target_label: __metrics_path__
+        regex: (.+)
+        replacement: ${1}/actuator/prometheus
+      - source_labels: [service]
+        target_label: service
+    static_configs:
+      - targets: ["brain:13001"]
+        labels: { service: brain, __meta_context_path: /brain }
+      - targets: ["vectorizator:13002"]
+        labels: { service: vectorizator, __meta_context_path: /vectorizator }
+      - targets: ["graphicator:13003"]
+        labels: { service: graphicator, __meta_context_path: /graphicator }
+      - targets: ["chunker:13004"]
+        labels: { service: chunker, __meta_context_path: /chunker }
+      - targets: ["git:13005"]
+        labels: { service: git, __meta_context_path: /git }
+      - targets: ["filesystem:13006"]
+        labels: { service: filesystem, __meta_context_path: /filesystem }
+      - targets: ["uploads:13007"]
+        labels: { service: uploads, __meta_context_path: /uploads }
+      - targets: ["userspace:13008"]
+        labels: { service: userspace, __meta_context_path: /userspace }
+      - targets: ["sharepoint:13009"]
+        labels: { service: sharepoint, __meta_context_path: /sharepoint }
+      - targets: ["confluence:13010"]
+        labels: { service: confluence, __meta_context_path: /confluence }
+      - targets: ["jira:13011"]
+        labels: { service: jira, __meta_context_path: /jira }
+      - targets: ["aws-s3:13012"]
+        labels: { service: aws-s3, __meta_context_path: /aws-s3 }
+      - targets: ["googledrive:13013"]
+        labels: { service: googledrive, __meta_context_path: /googledrive }
+      - targets: ["mcpclient:13014"]
+        labels: { service: mcpclient, __meta_context_path: /mcpclient }
+      - targets: ["integration:13015"]
+        labels: { service: integration, __meta_context_path: /integration }
+      - targets: ["fulltextor:13016"]
+        labels: { service: fulltextor, __meta_context_path: /fulltextor }
+      - targets: ["heimdall:13018"]
+        labels: { service: heimdall, __meta_context_path: /heimdall }
+      - targets: ["tyr:13019"]
+        labels: { service: tyr, __meta_context_path: /tyr }

--- a/dockers/gebo.microservices/tempo-config.yaml
+++ b/dockers/gebo.microservices/tempo-config.yaml
@@ -1,0 +1,26 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  trace_idle_period: 10s
+
+compactor:
+  compaction:
+    block_retention: 168h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal

--- a/gebo.apps.parent/gebo.ai.app/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.ai.app/src/main/resources/application.yml
@@ -1,4 +1,5 @@
 springdoc.api-docs.version: OPENAPI_3_0
+spring.application.name: gebo-ai-monolith
 logging:
   level:
     root: INFO
@@ -16,6 +17,21 @@ server:
     enabled: true
   servlet:
     contextPath: /
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus,metrics
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  tracing:
+    sampling:
+      probability: ${MANAGEMENT_TRACING_SAMPLING_PROBABILITY:1.0}
+  otlp:
+    tracing:
+      endpoint: ${MANAGEMENT_OTLP_TRACING_ENDPOINT:http://localhost:4318/v1/traces}
 spring.servlet.multipart:
   enabled: true
   maxFileSize: 100MB

--- a/gebo.apps.parent/gebo.ai.app/src/main/resources/logback-spring.xml
+++ b/gebo.apps.parent/gebo.ai.app/src/main/resources/logback-spring.xml
@@ -5,7 +5,7 @@
 		class="ch.qos.logback.core.ConsoleAppender">
 		<layout class="ch.qos.logback.classic.PatternLayout">
 			<Pattern>
-				%date [%thread] %-5level %logger{36}:%line - %msg%n
+				%date [%thread] %-5level %logger{36}:%line [%X{traceId:-},%X{spanId:-}] - %msg%n
 			</Pattern>
 		</layout>
 	</appender>
@@ -14,7 +14,7 @@
 		<file>${LOGS}/ai.gebo.monolithic.app.log</file>
 		<encoder
 			class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-			<Pattern>%date [%thread] %-5level %logger{36}:%line - %msg%n
+			<Pattern>%date [%thread] %-5level %logger{36}:%line [%X{traceId:-},%X{spanId:-}] - %msg%n
 			</Pattern>
 		</encoder>
 

--- a/gebo.apps.parent/gebo.apps.monolithic.starter/pom.xml
+++ b/gebo.apps.parent/gebo.apps.monolithic.starter/pom.xml
@@ -134,6 +134,11 @@
 		</dependency>
 		<dependency>
 			<groupId>ai.gebo.architecture</groupId>
+			<artifactId>gebo.architecture.telemetry</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ai.gebo.architecture</groupId>
 			<artifactId>gebo.architecture.documents.cache.impl</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/gateway.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/gateway.gebo.ai/pom.xml
@@ -28,6 +28,14 @@
 			<artifactId>gebo.microservices.topology</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!-- Not pulled in transitively: the gateway depends on gebo.microservices.topology
+		     directly rather than on gebo.microservices.starter, so telemetry (actuator +
+		     Micrometer + tracing) has to be added explicitly here. -->
+		<dependency>
+			<groupId>ai.gebo.architecture</groupId>
+			<artifactId>gebo.architecture.telemetry</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		<!--
 		  The Angular web UI. The gateway is the edge of the microservices
 		  deployment, so it is the service that serves the UI to the browser:

--- a/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/IMessageEnvelopeFactory.java
+++ b/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/IMessageEnvelopeFactory.java
@@ -1,0 +1,29 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.application.messaging;
+
+import ai.gebo.application.messaging.model.GMessageEnvelope;
+
+/**
+ * Injectable factory for {@link GMessageEnvelope} creation, mirroring
+ * {@link GMessageEnvelope#newMessageFrom}. Introduced so envelope creation has
+ * a Spring-managed seam: a static factory method has no path to a
+ * Spring-managed bean (e.g. a Micrometer {@code Tracer}), while an injectable
+ * factory does. The default implementation ({@code DefaultMessageEnvelopeFactory})
+ * simply delegates to the existing static logic; a tracing-aware override
+ * lives in {@code gebo.architecture.telemetry}.
+ */
+public interface IMessageEnvelopeFactory {
+
+	<T extends IGMessagePayloadType> GMessageEnvelope<T> newMessageFrom(IGMessageEmitter system, T payload);
+
+	<T extends IGMessagePayloadType> GMessageEnvelope<T> newMessageFrom(IGMessageEmitter system, T payload,
+			String user);
+}

--- a/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/impl/DefaultMessageEnvelopeFactory.java
+++ b/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/impl/DefaultMessageEnvelopeFactory.java
@@ -1,0 +1,42 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.application.messaging.impl;
+
+import org.springframework.stereotype.Component;
+
+import ai.gebo.application.messaging.IGMessageEmitter;
+import ai.gebo.application.messaging.IGMessagePayloadType;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
+import ai.gebo.application.messaging.model.GMessageEnvelope;
+
+/**
+ * Default {@link IMessageEnvelopeFactory}: delegates to
+ * {@link GMessageEnvelope}'s static factory methods, unchanged. Always
+ * registered (deliberately not {@code @ConditionalOnMissingBean}: plain
+ * {@code @Component} beans across different modules have no guaranteed scan
+ * order, and the tracing-aware override in {@code gebo.architecture.telemetry}
+ * depends on this concrete bean existing to delegate to - a flipped condition
+ * would break that dependency). Where both beans exist, {@code @Primary} on
+ * the tracing-aware override picks it over this one.
+ */
+@Component
+public class DefaultMessageEnvelopeFactory implements IMessageEnvelopeFactory {
+
+	@Override
+	public <T extends IGMessagePayloadType> GMessageEnvelope<T> newMessageFrom(IGMessageEmitter system, T payload) {
+		return GMessageEnvelope.newMessageFrom(system, payload);
+	}
+
+	@Override
+	public <T extends IGMessagePayloadType> GMessageEnvelope<T> newMessageFrom(IGMessageEmitter system, T payload,
+			String user) {
+		return GMessageEnvelope.newMessageFrom(system, payload, user);
+	}
+}

--- a/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/model/GMessageEnvelope.java
+++ b/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/model/GMessageEnvelope.java
@@ -12,7 +12,9 @@ package ai.gebo.application.messaging.model;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.data.annotation.Id;
@@ -74,6 +76,12 @@ public class GMessageEnvelope<PayloadType extends IGMessagePayloadType> implemen
 	private String workflowStepId = null;
 	// components to forward processed results or current message
 	private List<GMessagingComponentRef> onProcessForwardDestionations = null;
+	// Distributed trace context carried across both in-process dispatch and the
+	// RabbitMQ hop (the envelope round-trips as JSON either way, so this survives
+	// the wire without any AMQP-specific header plumbing). Populated by whichever
+	// IMessageEnvelopeFactory implementation is active (see gebo.application.messaging
+	// and its tracing-aware override in gebo.architecture.telemetry).
+	private Map<String, String> traceContext = null;
 
 	/**
 	 * Default constructor for GMessageEnvelope.
@@ -103,6 +111,7 @@ public class GMessageEnvelope<PayloadType extends IGMessagePayloadType> implemen
 		dest.delivered = env.getDelivered();
 		dest.processed = env.getProcessed();
 		dest.id = env.getId();
+		dest.traceContext = env.getTraceContext();
 		return dest;
 	}
 
@@ -455,5 +464,37 @@ public class GMessageEnvelope<PayloadType extends IGMessagePayloadType> implemen
 
 	public void setWorkflowType(GWorkflowType workflowType) {
 		this.workflowType = workflowType;
+	}
+
+	/**
+	 * Gets the distributed trace context carried by this envelope, if any.
+	 *
+	 * @return the trace context as a plain map (propagator-format), or null if none.
+	 */
+	public Map<String, String> getTraceContext() {
+		return traceContext;
+	}
+
+	/**
+	 * Sets the distributed trace context to be carried by this envelope.
+	 *
+	 * @param traceContext the trace context to set.
+	 */
+	public void setTraceContext(Map<String, String> traceContext) {
+		this.traceContext = traceContext;
+	}
+
+	/**
+	 * Convenience setter used by trace-context propagators to add a single
+	 * key/value pair, creating the underlying map if necessary.
+	 *
+	 * @param key   the propagator field name.
+	 * @param value the propagator field value.
+	 */
+	public void putTraceContextField(String key, String value) {
+		if (this.traceContext == null) {
+			this.traceContext = new HashMap<String, String>();
+		}
+		this.traceContext.put(key, value);
 	}
 }

--- a/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/orchestration/IGMessageDeliveryObserver.java
+++ b/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/orchestration/IGMessageDeliveryObserver.java
@@ -1,0 +1,32 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.application.messaging.orchestration;
+
+import ai.gebo.application.messaging.model.GMessageEnvelope;
+
+/**
+ * Wraps the point where a message is actually handed to a receiver's business
+ * logic - {@link MessageReceiverRunner}'s dedicated-thread delivery loop and
+ * {@link ThreadMessageReceiverMultiplexer}'s synchronous backup-receiver path.
+ *
+ * <p>
+ * Both of those execution paths run on plain objects manually instantiated by
+ * {@link MultiThreadedMessagesOrchestrator} and handed to
+ * {@code IGeboThreadManager}, so they are never reached by a Spring AOP proxy.
+ * This interface is the explicit collaborator that reaches them instead - the
+ * delivery-side counterpart of {@code IMessageEnvelopeFactory} on the creation
+ * side. The default implementation is a no-op; a tracing-aware override lives
+ * in {@code gebo.architecture.telemetry}.
+ * </p>
+ */
+public interface IGMessageDeliveryObserver {
+
+	void aroundDelivery(GMessageEnvelope<?> envelope, Runnable delivery);
+}

--- a/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/orchestration/MessageReceiverRunner.java
+++ b/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/orchestration/MessageReceiverRunner.java
@@ -60,14 +60,19 @@ class MessageReceiverRunner implements IGMessageReceiver, IGRunnable {
     // Single instance of the message receiver
     private IGMessageReceiver instance = null;
 
+    // Observer wrapping the actual delivery of a message to the receiver instance
+    private final IGMessageDeliveryObserver deliveryObserver;
+
     /**
      * Constructor for MessageReceiverRunner.
      * Initializes the factory and assesses the timeout capabilities.
-     * 
+     *
      * @param factory The message receiver factory to be used.
+     * @param deliveryObserver Observer wrapping the actual delivery call.
      */
-    MessageReceiverRunner(IGMessageReceiverFactory factory) {
+    MessageReceiverRunner(IGMessageReceiverFactory factory, IGMessageDeliveryObserver deliveryObserver) {
         this.factory = factory;
+        this.deliveryObserver = deliveryObserver;
         this.timeOutFactory = this.factory instanceof IGTimedOutMessageReceiverFactory;
         this.timeout = (this.timeOutFactory) ? ((IGTimedOutMessageReceiverFactory) this.factory).getReceivingTimeout()
                 : Long.MAX_VALUE;
@@ -181,7 +186,7 @@ class MessageReceiverRunner implements IGMessageReceiver, IGRunnable {
                 }
                 for (GMessageEnvelope msg : copiedMessages) {
                     try {
-                        instance.accept(msg);
+                        deliveryObserver.aroundDelivery(msg, () -> instance.accept(msg));
                     } catch (Throwable th) {
                         LOGGER.error("Exception on message delivery:" + msg.toString(), th);
                     }

--- a/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/orchestration/MultiThreadedMessagesOrchestrator.java
+++ b/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/orchestration/MultiThreadedMessagesOrchestrator.java
@@ -56,6 +56,10 @@ public class MultiThreadedMessagesOrchestrator implements ApplicationListener<Co
     @Autowired
     TimeoutCallbackHandler callbackHandler;
 
+    // Observer wrapping the actual delivery of a message to a receiver's business logic
+    @Autowired
+    IGMessageDeliveryObserver deliveryObserver;
+
     // List of multiplexed message receivers
     protected List<ThreadMessageReceiverMultiplexer> multiplexingReceivers = new ArrayList<ThreadMessageReceiverMultiplexer>();
 
@@ -87,7 +91,7 @@ public class MultiThreadedMessagesOrchestrator implements ApplicationListener<Co
                         + howToCreate + " instances");
                 List<MessageReceiverRunner> receivers = new ArrayList<MessageReceiverRunner>();
                 for (int i = 0; i < howToCreate; i++) {
-                    MessageReceiverRunner receiver = new MessageReceiverRunner(factory);
+                    MessageReceiverRunner receiver = new MessageReceiverRunner(factory, deliveryObserver);
                     receivers.add(receiver);
                 }
                 allRunnables.addAll(receivers);
@@ -95,7 +99,7 @@ public class MultiThreadedMessagesOrchestrator implements ApplicationListener<Co
                 IGMessageReceiver backupReceiver = factory.useSenderThread() ? factory.create() : null;
                 // Create a multiplexer for handling multiple receivers
                 ThreadMessageReceiverMultiplexer receiver = new ThreadMessageReceiverMultiplexer(factory, receivers,
-                        backupReceiver);
+                        backupReceiver, deliveryObserver);
                 multiplexingReceivers.add(receiver);
                 // Register the receiver with the callback handler
                 callbackHandler.add(receiver);

--- a/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/orchestration/NoOpMessageDeliveryObserver.java
+++ b/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/orchestration/NoOpMessageDeliveryObserver.java
@@ -1,0 +1,30 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.application.messaging.orchestration;
+
+import org.springframework.stereotype.Component;
+
+import ai.gebo.application.messaging.model.GMessageEnvelope;
+
+/**
+ * Default {@link IGMessageDeliveryObserver}: runs the delivery with no
+ * instrumentation. Always registered (see {@code DefaultMessageEnvelopeFactory}
+ * for why this deliberately isn't {@code @ConditionalOnMissingBean}); where a
+ * tracing-aware override is also present (see {@code gebo.architecture.telemetry}),
+ * its {@code @Primary} annotation picks it over this one.
+ */
+@Component
+public class NoOpMessageDeliveryObserver implements IGMessageDeliveryObserver {
+
+	@Override
+	public void aroundDelivery(GMessageEnvelope<?> envelope, Runnable delivery) {
+		delivery.run();
+	}
+}

--- a/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/orchestration/ThreadMessageReceiverMultiplexer.java
+++ b/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/orchestration/ThreadMessageReceiverMultiplexer.java
@@ -59,20 +59,25 @@ class ThreadMessageReceiverMultiplexer implements IGMessageReceiver {
 	// Indicates if the backup receiver is currently executing
 	protected boolean backupReceiverMonitorExecuting = false;
 
+	// Observer wrapping the actual delivery of a message to the backup receiver
+	protected final IGMessageDeliveryObserver deliveryObserver;
+
 	/**
 	 * Constructor to initialize the multiplexer with the given factory, receivers, and backup receiver.
 	 *
 	 * @param factory The factory to create message receivers
 	 * @param receivers The list of message receiver runners to manage
 	 * @param backupReceiver The backup receiver used when all threads are busy
+	 * @param deliveryObserver Observer wrapping the synchronous backup-receiver delivery call
 	 */
 	ThreadMessageReceiverMultiplexer(IGMessageReceiverFactory factory, List<MessageReceiverRunner> receivers,
-			IGMessageReceiver backupReceiver) {
-		
+			IGMessageReceiver backupReceiver, IGMessageDeliveryObserver deliveryObserver) {
+
 		this.receivers = receivers;
 		this.backupReceiver = backupReceiver;
 		this.factory = factory;
-		
+		this.deliveryObserver = deliveryObserver;
+
 		// Set the timeout if the factory supports timeouts
 		if (factory instanceof IGTimedOutMessageReceiverFactory) {
 			timeout = ((IGTimedOutMessageReceiverFactory) factory).getReceivingTimeout();
@@ -165,7 +170,7 @@ class ThreadMessageReceiverMultiplexer implements IGMessageReceiver {
 						backupReceiverMonitorExecuting = true;
 						lastReceviedTime = System.currentTimeMillis();
 						lastInteractionWasTimeout = false;
-						backupReceiver.accept(msg);
+						deliveryObserver.aroundDelivery(msg, () -> backupReceiver.accept(msg));
 						lastReceviedTime = System.currentTimeMillis();
 					} finally {
 						backupReceiverMonitorExecuting = false;

--- a/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/workflow/impl/WorkflowRouterImpl.java
+++ b/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/workflow/impl/WorkflowRouterImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import ai.gebo.application.messaging.IGMessageBroker;
 import ai.gebo.application.messaging.IGMessageEmitter;
 import ai.gebo.application.messaging.IGMessagePayloadType;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
 import ai.gebo.application.messaging.model.GMessageEnvelope;
 import ai.gebo.application.messaging.model.GMessagingComponentRef;
 import ai.gebo.application.messaging.workflow.GWorkflowType;
@@ -24,6 +25,7 @@ import lombok.AllArgsConstructor;
 public class WorkflowRouterImpl implements IWorkflowRouter {
 	private final IGMessageBroker broker;
 	private final IWorkflowMessagesRouterRepositoryPattern workflowMessagesRouterRepositoryPattern;
+	private final IMessageEnvelopeFactory envelopeFactory;
 	private final static Logger LOGGER = LoggerFactory.getLogger(WorkflowRouterImpl.class);
 
 	@Override
@@ -43,7 +45,7 @@ public class WorkflowRouterImpl implements IWorkflowRouter {
 		}
 		for (GMessagingComponentRef target : destinations) {
 			try {
-				GMessageEnvelope<IGMessagePayloadType> envelope = GMessageEnvelope.newMessageFrom(emitter,
+				GMessageEnvelope<IGMessagePayloadType> envelope = envelopeFactory.newMessageFrom(emitter,
 						messageContext.getPayload());
 				envelope.setWorkflowType(workflowType);
 				envelope.setWorkflowId(target.getWorkflowId());

--- a/gebo.architecture.parent/gebo.architecture.chat.abstraction.layer/src/main/java/ai/gebo/llms/chat/abstraction/layer/services/impl/GChatSessionLifeCycleServiceImpl.java
+++ b/gebo.architecture.parent/gebo.architecture.chat.abstraction.layer/src/main/java/ai/gebo/llms/chat/abstraction/layer/services/impl/GChatSessionLifeCycleServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 import ai.gebo.application.messaging.IGMessageBroker;
 import ai.gebo.application.messaging.IGMessageEmitter;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
 import ai.gebo.application.messaging.SystemComponentType;
 import ai.gebo.application.messaging.model.GMessageEnvelope;
 import ai.gebo.application.messaging.model.GStandardModulesConstraints;
@@ -97,6 +98,7 @@ public class GChatSessionLifeCycleServiceImpl implements IGChatSessionLifeCycleS
 	private final IGPromptConfigDao promptsDao;
 	private final IGChatSessionStateShrinkerService shrinkerService;
 	private final IGEmbeddingModelRuntimeConfigurationDao embeddingModelsRuntimeDao;
+	private final IMessageEnvelopeFactory envelopeFactory;
 
 	@NoArgsConstructor
 
@@ -603,7 +605,7 @@ public class GChatSessionLifeCycleServiceImpl implements IGChatSessionLifeCycleS
 			SessionShrinkRequestPayload checkPayload = new SessionShrinkRequestPayload();
 			checkPayload.setTokensBudget(budgetSize);
 			checkPayload.setUserChatSessionCode(code);
-			GMessageEnvelope<SessionShrinkRequestPayload> envelope = GMessageEnvelope.newMessageFrom(this,
+			GMessageEnvelope<SessionShrinkRequestPayload> envelope = envelopeFactory.newMessageFrom(this,
 					checkPayload);
 			envelope.setTargetModule(GStandardModulesConstraints.CORE_MODULE);
 			envelope.setTargetComponent(SessionShrinkMessagesReceiver.SESSION_SHRINKER);

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/workflows/compute/service/impl/WorkflowStatusEmitter.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/workflows/compute/service/impl/WorkflowStatusEmitter.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import ai.gebo.application.messaging.IGMessageBroker;
 import ai.gebo.application.messaging.IGMessageEmitter;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
 import ai.gebo.application.messaging.SystemComponentType;
 import ai.gebo.application.messaging.model.GMessageEnvelope;
 import ai.gebo.application.messaging.model.GStandardModulesConstraints;
@@ -22,6 +23,7 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class WorkflowStatusEmitter implements IGMessageEmitter {
 	private final IGRuntimeBinder runtimeBinder;
+	private final IMessageEnvelopeFactory envelopeFactory;
 
 	@Override
 	public String getMessagingModuleId() {
@@ -45,7 +47,7 @@ public class WorkflowStatusEmitter implements IGMessageEmitter {
 	}
 
 	private void _broadcast(GBaseWorkflowStatusPayload payload) {
-		GMessageEnvelope<GBaseWorkflowStatusPayload> message = GMessageEnvelope.newMessageFrom(this, payload);
+		GMessageEnvelope<GBaseWorkflowStatusPayload> message = envelopeFactory.newMessageFrom(this, payload);
 		IGMessageBroker broker = runtimeBinder.getImplementationOf(IGMessageBroker.class);
 		broker.broadcast(message);
 	}

--- a/gebo.architecture.parent/gebo.architecture.contentsystems.abstraction.layer/pom.xml
+++ b/gebo.architecture.parent/gebo.architecture.contentsystems.abstraction.layer/pom.xml
@@ -11,6 +11,10 @@
 	<dependencies>
 
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>ai.gebo.architecture</groupId>
 			<artifactId>gebo.architecture.contenthandling.interfaces</artifactId>
 			<version>${project.version}</version>

--- a/gebo.architecture.parent/gebo.architecture.contentsystems.abstraction.layer/src/main/java/ai/gebo/jobs/services/impl/JobStatusEmitter.java
+++ b/gebo.architecture.parent/gebo.architecture.contentsystems.abstraction.layer/src/main/java/ai/gebo/jobs/services/impl/JobStatusEmitter.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import ai.gebo.application.messaging.IGMessageBroker;
 import ai.gebo.application.messaging.IGMessageEmitter;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
 import ai.gebo.application.messaging.SystemComponentType;
 import ai.gebo.application.messaging.model.GMessageEnvelope;
 import ai.gebo.application.messaging.model.GStandardModulesConstraints;
@@ -23,6 +24,7 @@ import lombok.AllArgsConstructor;
 public class JobStatusEmitter implements IGMessageEmitter {
 	private static final String JOB_STATUS_NOTIFIER = "job-status-notifier";
 	private final IGRuntimeBinder runtimeBinder;
+	private final IMessageEnvelopeFactory envelopeFactory;
 
 	@Override
 	public String getMessagingModuleId() {
@@ -46,7 +48,7 @@ public class JobStatusEmitter implements IGMessageEmitter {
 	}
 
 	private void _broadcast(GBaseWorkflowStatusPayload payload) {
-		GMessageEnvelope<GBaseWorkflowStatusPayload> message = GMessageEnvelope.newMessageFrom(this, payload);
+		GMessageEnvelope<GBaseWorkflowStatusPayload> message = envelopeFactory.newMessageFrom(this, payload);
 		IGMessageBroker broker = runtimeBinder.getImplementationOf(IGMessageBroker.class);
 		broker.broadcast(message);
 	}

--- a/gebo.architecture.parent/gebo.architecture.contentsystems.abstraction.layer/src/main/java/ai/gebo/systems/abstraction/layer/controllers/GAbstractSystemsArchitectureController.java
+++ b/gebo.architecture.parent/gebo.architecture.contentsystems.abstraction.layer/src/main/java/ai/gebo/systems/abstraction/layer/controllers/GAbstractSystemsArchitectureController.java
@@ -13,9 +13,11 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import ai.gebo.application.messaging.IGMessageBroker;
 import ai.gebo.application.messaging.IGMessageEmitter;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
 import ai.gebo.application.messaging.SystemComponentType;
 import ai.gebo.application.messaging.model.GMessageEnvelope;
 import ai.gebo.application.messaging.model.GStandardModulesConstraints;
@@ -36,14 +38,16 @@ import ai.gebo.knlowledgebase.model.systems.GContentManagementSystem;
 import ai.gebo.model.OperationStatus;
 import ai.gebo.security.services.IGSecurityService;
 import ai.gebo.systems.abstraction.layer.NoContentConsumingSessionParam;
+import io.micrometer.observation.annotation.Observed;
 
 /**
  * AI generated comments Abstract controller for system architectures,
  * responsible for managing operations related to systems and endpoints.
- * 
+ *
  * @param <SystemType>   The type of the content management system.
  * @param <EndpointType> The type of the project endpoint.
  */
+@Observed(name = "gebo.systems.integration")
 public class GAbstractSystemsArchitectureController<SystemType extends GContentManagementSystem, EndpointType extends GProjectEndpoint> {
 	// Logger for logging messages
 	protected Logger LOGGER = LoggerFactory.getLogger(getClass());
@@ -61,6 +65,12 @@ public class GAbstractSystemsArchitectureController<SystemType extends GContentM
 	protected final IGEntityProcessingRunnableFactoryRepositoryPattern entityProcessingRunnableFactory;
 	protected final IGGeboIngestionJobQueueService jobQueueService;
 	protected final IEntityReplicationService replicationService;
+	// Field-injected rather than threaded through the constructor: this base class
+	// already has 8 constructor params and ~10 per-system subclasses that would
+	// all need updating; @Autowired works here since every concrete subclass is a
+	// Spring-managed @RestController.
+	@Autowired
+	protected IMessageEnvelopeFactory envelopeFactory;
 
 	/**
 	 * Nested emitter class for handling messaging from the controller.
@@ -134,19 +144,19 @@ public GAbstractSystemsArchitectureController(IGPersistentObjectManager persiste
 		// persistentObjectManager.delete(endpoint);
 
 		// Create and send messages to indicate deletion
-		GMessageEnvelope<GDeletedProjectEndpointPayload> message = GMessageEnvelope.newMessageFrom(controllerEmitter,
+		GMessageEnvelope<GDeletedProjectEndpointPayload> message = envelopeFactory.newMessageFrom(controllerEmitter,
 				newDeletedEndpointPayload(centralized, contentManagementSystemCode), userid);
 		message.setTargetModule(controllerEmitter.getMessagingModuleId());
 		message.setTargetComponent(GStandardModulesConstraints.RESOURCES_DISPOSE_COMPONENT);
 		messageBroker.accept(message);
 
-		message = GMessageEnvelope.newMessageFrom(controllerEmitter,
+		message = envelopeFactory.newMessageFrom(controllerEmitter,
 				newDeletedEndpointPayload(centralized, contentManagementSystemCode), userid);
 		message.setTargetModule(GStandardModulesConstraints.CORE_MODULE);
 		message.setTargetComponent(GStandardModulesConstraints.MONGO_DISPOSE_DOCUMENTS_COMPONENT);
 		messageBroker.accept(message);
 
-		message = GMessageEnvelope.newMessageFrom(controllerEmitter,
+		message = envelopeFactory.newMessageFrom(controllerEmitter,
 				newDeletedEndpointPayload(centralized, contentManagementSystemCode), userid);
 		message.setTargetModule(GStandardModulesConstraints.VECTORIZATOR_MODULE);
 		message.setTargetComponent(GStandardModulesConstraints.VECTORIZATION_DISPOSE_COMPONENT);

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractBaseChatModelsConfigurationCRUDController.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractBaseChatModelsConfigurationCRUDController.java
@@ -25,6 +25,7 @@ import ai.gebo.llms.abstraction.layer.model.GBaseChatModelConfig;
 import ai.gebo.llms.abstraction.layer.services.IGChatModelRuntimeConfigurationDao;
 import ai.gebo.llms.abstraction.layer.services.IGConfigurableChatModel;
 import ai.gebo.model.OperationStatus;
+import io.micrometer.observation.annotation.Observed;
 import lombok.AllArgsConstructor;
 
 /**
@@ -33,10 +34,11 @@ import lombok.AllArgsConstructor;
  *
  * @param <ChatModelConfigType> The type of chat model configuration.
  * @param <ModelChoice> The type of model choice.
- * 
+ *
  * AI generated comments
  */
 @AllArgsConstructor
+@Observed(name = "gebo.llms.config.crud")
 public abstract class AbstractBaseChatModelsConfigurationCRUDController<ChatModelConfigType extends GBaseChatModelConfig, ModelChoice extends GBaseChatModelChoice> {
 
 	// Logger instance for logging operations and exceptions

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractBaseEmbeddingModelsConfigurationCRUDController.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractBaseEmbeddingModelsConfigurationCRUDController.java
@@ -22,6 +22,7 @@ import ai.gebo.llms.abstraction.layer.model.GBaseEmbeddingModelConfig;
 import ai.gebo.llms.abstraction.layer.services.IGConfigurableEmbeddingModel;
 import ai.gebo.llms.abstraction.layer.services.IGEmbeddingModelRuntimeConfigurationDao;
 import ai.gebo.model.OperationStatus;
+import io.micrometer.observation.annotation.Observed;
 import lombok.AllArgsConstructor;
 
 /**
@@ -36,6 +37,7 @@ import lombok.AllArgsConstructor;
  * @param <ModelChoice>              The type of the model choice.
  */
 @AllArgsConstructor
+@Observed(name = "gebo.llms.config.crud")
 public abstract class AbstractBaseEmbeddingModelsConfigurationCRUDController<EmbeddingModelConfigType extends GBaseEmbeddingModelConfig, ModelChoice extends GBaseEmbeddingModelChoice> {
 	protected final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
 

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractImageModelsConfigurationCRUDController.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractImageModelsConfigurationCRUDController.java
@@ -21,6 +21,7 @@ import ai.gebo.llms.abstraction.layer.model.GBaseImageModelConfig;
 import ai.gebo.llms.abstraction.layer.services.IGConfigurableImageModel;
 import ai.gebo.llms.abstraction.layer.services.IGImageModelRuntimeConfigurationDao;
 import ai.gebo.model.OperationStatus;
+import io.micrometer.observation.annotation.Observed;
 import lombok.AllArgsConstructor;
 
 /**
@@ -36,6 +37,7 @@ import lombok.AllArgsConstructor;
  * @param <ModelChoice>          The type of model choice.
  */
 @AllArgsConstructor
+@Observed(name = "gebo.llms.config.crud")
 public abstract class AbstractImageModelsConfigurationCRUDController<ImageModelConfigType extends GBaseImageModelConfig, ModelChoice extends GBaseImageModelChoice> {
 
 	protected final Logger LOGGER = LoggerFactory.getLogger(this.getClass());

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractRankerModelsConfigurationCRUDController.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractRankerModelsConfigurationCRUDController.java
@@ -23,6 +23,7 @@ import ai.gebo.llms.abstraction.layer.services.IGConfigurableRankerModel;
 import ai.gebo.llms.abstraction.layer.services.IGRankerModelConfigurationSupportService;
 import ai.gebo.llms.abstraction.layer.services.IGRankerModelRuntimeConfigurationDao;
 import ai.gebo.model.OperationStatus;
+import io.micrometer.observation.annotation.Observed;
 import lombok.AllArgsConstructor;
 
 /**
@@ -32,10 +33,11 @@ import lombok.AllArgsConstructor;
  *
  * @param <RankerModelType> The type of chat model configuration.
  * @param <ModelChoice>     The type of model choice.
- * 
+ *
  *                          AI generated comments
  */
 @AllArgsConstructor
+@Observed(name = "gebo.llms.config.crud")
 public abstract class AbstractRankerModelsConfigurationCRUDController<RankerModelType extends GBaseRankerModelConfig, ModelChoice extends GBaseRankerModelChoice> {
 
 	// Logger instance for logging operations and exceptions

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractTextToSpeechModelsConfigurationCRUDController.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractTextToSpeechModelsConfigurationCRUDController.java
@@ -21,6 +21,7 @@ import ai.gebo.llms.abstraction.layer.model.GBaseTextToSpeachModelConfig;
 import ai.gebo.llms.abstraction.layer.services.IGConfigurableTextToSpeechModel;
 import ai.gebo.llms.abstraction.layer.services.IGTextToSpeechModelRuntimeConfigurationDao;
 import ai.gebo.model.OperationStatus;
+import io.micrometer.observation.annotation.Observed;
 import lombok.AllArgsConstructor;
 
 /**
@@ -37,6 +38,7 @@ import lombok.AllArgsConstructor;
  * @param <ModelChoice>                  The type of model choice.
  */
 @AllArgsConstructor
+@Observed(name = "gebo.llms.config.crud")
 public abstract class AbstractTextToSpeechModelsConfigurationCRUDController<TextToSpeechModelConfigType extends GBaseTextToSpeachModelConfig, ModelChoice extends GBaseTextToSpeachModelChice> {
 
 	protected final Logger LOGGER = LoggerFactory.getLogger(this.getClass());

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractTranscriptModelsConfigurationCRUDController.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/controllers/AbstractTranscriptModelsConfigurationCRUDController.java
@@ -21,6 +21,7 @@ import ai.gebo.llms.abstraction.layer.model.GBaseTranscriptModelConfig;
 import ai.gebo.llms.abstraction.layer.services.IGConfigurableTranscriptModel;
 import ai.gebo.llms.abstraction.layer.services.IGTranscriptModelRuntimeConfigurationDao;
 import ai.gebo.model.OperationStatus;
+import io.micrometer.observation.annotation.Observed;
 import lombok.AllArgsConstructor;
 
 /**
@@ -36,6 +37,7 @@ import lombok.AllArgsConstructor;
  * @param <ModelChoice>                The type of model choice.
  */
 @AllArgsConstructor
+@Observed(name = "gebo.llms.config.crud")
 public abstract class AbstractTranscriptModelsConfigurationCRUDController<TranscriptModelConfigType extends GBaseTranscriptModelConfig, ModelChoice extends GBaseTranscriptModelChoice> {
 
 	protected final Logger LOGGER = LoggerFactory.getLogger(this.getClass());

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/services/GAbstractConfigurableChatModel.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/services/GAbstractConfigurableChatModel.java
@@ -41,6 +41,7 @@ import org.springframework.ai.tool.ToolCallback;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
+import io.micrometer.observation.ObservationRegistry;
 import ai.gebo.architecture.ai.model.ContextContentRequired;
 import ai.gebo.architecture.ai.model.GPromptTemplateConfig;
 import ai.gebo.architecture.ai.model.ITokensCountable;
@@ -84,6 +85,14 @@ public abstract class GAbstractConfigurableChatModel<ModelConfig extends GBaseCh
 	protected final IGDocumentContentRendererProvider rendererFactory;
 	protected final IGToolCallbackSourceRepositoryPattern toolCallbacksRepository;
 	protected final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	/**
+	 * The application's shared Micrometer {@link ObservationRegistry}, passed
+	 * down to {@link #configureModel(GBaseChatModelConfig, GChatModelType, ToolCallingManager)}
+	 * implementations so Spring AI's built-in chat-model observability actually
+	 * reports into it, instead of each vendor building its own disconnected
+	 * registry.
+	 */
+	protected final ObservationRegistry observationRegistry;
 	protected static final ObjectMapper mapper = new ObjectMapper();
 
 	protected abstract IGConfigurableChatModel cloneMeWithInjection();
@@ -92,10 +101,12 @@ public abstract class GAbstractConfigurableChatModel<ModelConfig extends GBaseCh
 	 * Default constructor for GAbstractConfigurableChatModel.
 	 */
 	public GAbstractConfigurableChatModel(IGDocumentContentRendererProvider rendererFactory,
-			IGToolCallbackSourceRepositoryPattern toolCallbacksRepository, IChatModelUsageAdvisorFactory usageAdvisorFactory) {
+			IGToolCallbackSourceRepositoryPattern toolCallbacksRepository,
+			IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
 		this.rendererFactory = rendererFactory;
 		this.toolCallbacksRepository = toolCallbacksRepository;
 		this.usageAdvisorFactory = usageAdvisorFactory;
+		this.observationRegistry = observationRegistry;
 	}
 
 	/**

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/services/GAbstractConfigurableEmbeddingModel.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/services/GAbstractConfigurableEmbeddingModel.java
@@ -12,6 +12,7 @@ package ai.gebo.llms.abstraction.layer.services;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.vectorstore.VectorStore;
 
+import io.micrometer.observation.ObservationRegistry;
 import ai.gebo.llms.abstraction.layer.model.GBaseEmbeddingModelConfig;
 import ai.gebo.llms.abstraction.layer.model.GEmbeddingModelType;
 import ai.gebo.llms.abstraction.layer.vectorstores.GAccountingExtendedVectorStoreAdapter;
@@ -49,13 +50,24 @@ public abstract class GAbstractConfigurableEmbeddingModel<ModelConfig extends GB
 	protected IGVectorStoreFactory storeFactory = null;
 
 	/**
+	 * The application's shared Micrometer {@link ObservationRegistry}, passed
+	 * down to {@link #configureModel(GBaseEmbeddingModelConfig, GEmbeddingModelType)}
+	 * implementations so Spring AI's built-in embedding-model observability
+	 * actually reports into it, instead of each vendor building its own
+	 * disconnected registry.
+	 */
+	protected final ObservationRegistry observationRegistry;
+
+	/**
 	 * Constructs a configurable embedding model with the specified vector store
 	 * factory provider.
-	 * 
+	 *
 	 * @param storeFactoryProvider Provider for the vector store factory.
 	 */
-	public GAbstractConfigurableEmbeddingModel(IGVectorStoreFactoryProvider storeFactoryProvider) {
+	public GAbstractConfigurableEmbeddingModel(IGVectorStoreFactoryProvider storeFactoryProvider,
+			ObservationRegistry observationRegistry) {
 		this.vectorStoreFactoryProvider = storeFactoryProvider;
+		this.observationRegistry = observationRegistry;
 	}
 
 	@Override

--- a/gebo.architecture.parent/gebo.architecture.replicator/src/main/java/ai/gebo/architecture/replicator/service/GAbstractReplicatorService.java
+++ b/gebo.architecture.parent/gebo.architecture.replicator/src/main/java/ai/gebo/architecture/replicator/service/GAbstractReplicatorService.java
@@ -3,6 +3,7 @@ package ai.gebo.architecture.replicator.service;
 import java.util.List;
 
 import ai.gebo.application.messaging.IGMessageEmitter;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
 import ai.gebo.application.messaging.SystemComponentType;
 import ai.gebo.application.messaging.model.GMessageEnvelope;
 import ai.gebo.architecture.environment.GeboApplicationArchitecture;
@@ -18,14 +19,17 @@ public abstract class GAbstractReplicatorService implements IEntityReplicationSe
     private final String messagingSystemId;
     private final GeboApplicationArchitecture architecture;
     private final IGReplicationsMap replicationsMap;
+    private final IMessageEnvelopeFactory envelopeFactory;
 
     protected GAbstractReplicatorService(String messagingModuleId, String messagingSystemId,
                                           GeboApplicationArchitecture architecture,
-                                          IGReplicationsMap replicationsMap) {
+                                          IGReplicationsMap replicationsMap,
+                                          IMessageEnvelopeFactory envelopeFactory) {
         this.messagingModuleId = messagingModuleId;
         this.messagingSystemId = messagingSystemId;
         this.architecture = architecture;
         this.replicationsMap = replicationsMap;
+        this.envelopeFactory = envelopeFactory;
     }
 
     @Override
@@ -65,7 +69,7 @@ public abstract class GAbstractReplicatorService implements IEntityReplicationSe
         payload.setDeleted(deleted);
 
         for (ReplicationMessageReceiver receiver : receivers) {
-            GMessageEnvelope<?> envelope = GMessageEnvelope.newMessageFrom(this, payload);
+            GMessageEnvelope<?> envelope = envelopeFactory.newMessageFrom(this, payload);
             envelope.setTargetModule(receiver.getMessagingModuleId());
             envelope.setTargetComponent(receiver.getMessagingSystemId());
             emit(envelope);

--- a/gebo.architecture.parent/gebo.architecture.scheduling/src/main/java/ai/gebo/architecture/scheduling/services/impl/GSchedulingTimeServiceImpl.java
+++ b/gebo.architecture.parent/gebo.architecture.scheduling/src/main/java/ai/gebo/architecture/scheduling/services/impl/GSchedulingTimeServiceImpl.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Component;
 import ai.gebo.application.messaging.IGMessageBroker;
 import ai.gebo.application.messaging.IGMessageEmitter;
 import ai.gebo.application.messaging.IGMessageReceiver;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
 import ai.gebo.application.messaging.SystemComponentType;
 import ai.gebo.application.messaging.model.GMessageEnvelope;
 import ai.gebo.application.messaging.model.GStandardModulesConstraints;
@@ -70,6 +71,8 @@ public class GSchedulingTimeServiceImpl implements IGSchedulingTimeService, IGMe
     protected IGPersistentObjectManager persistentObjectManager;
     @Autowired
     protected IGMessageBroker broker;
+    @Autowired
+    protected IMessageEnvelopeFactory envelopeFactory;
 
     /**
      * Default constructor.
@@ -265,7 +268,7 @@ public class GSchedulingTimeServiceImpl implements IGSchedulingTimeService, IGMe
         PublishProjectEndpointMessagePayload payload = new PublishProjectEndpointMessagePayload();
         payload.setProjectEndpoint(ref);
         payload.setCorrelationId(projectEndpointScheduledTask.getId());
-        GMessageEnvelope<PublishProjectEndpointMessagePayload> envelope = GMessageEnvelope.newMessageFrom(this,
+        GMessageEnvelope<PublishProjectEndpointMessagePayload> envelope = envelopeFactory.newMessageFrom(this,
                 payload);
         envelope.setTargetModule(GStandardModulesConstraints.ASYNC_PUBLISHING_JOB_MODULE);
         envelope.setTargetComponent(GStandardModulesConstraints.ASYNC_PUBLISHING_JOB_COMPONENT);

--- a/gebo.architecture.parent/gebo.architecture.telemetry/pom.xml
+++ b/gebo.architecture.parent/gebo.architecture.telemetry/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>ai.gebo.architecture</groupId>
+		<artifactId>gebo.architecture.parent</artifactId>
+		<version>1.0.2.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>gebo.architecture.telemetry</artifactId>
+	<dependencies>
+		<dependency>
+			<groupId>ai.gebo.architecture</groupId>
+			<artifactId>gebo.architecture.environment</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ai.gebo.architecture</groupId>
+			<artifactId>gebo.application.messaging</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<!-- Renamed from spring-boot-starter-aop in Spring Boot 4.x -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-aspectj</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-otel</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.opentelemetry</groupId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/gebo.architecture.parent/gebo.architecture.telemetry/src/main/java/ai/gebo/architecture/telemetry/GeboTelemetryConfig.java
+++ b/gebo.architecture.parent/gebo.architecture.telemetry/src/main/java/ai/gebo/architecture/telemetry/GeboTelemetryConfig.java
@@ -1,0 +1,47 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.architecture.telemetry;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MeterRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import ai.gebo.architecture.environment.GeboApplicationArchitecture;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.aop.ObservedAspect;
+
+/**
+ * Shared telemetry wiring for both the monolith and every microservice: tags
+ * every metric with the running application's name and architecture mode
+ * ({@code monolithic}/{@code microservices}), and registers the
+ * {@link ObservedAspect} that makes the {@code @Observed} annotation active
+ * anywhere in the codebase.
+ */
+@Configuration
+public class GeboTelemetryConfig {
+
+	@Bean
+	public MeterRegistryCustomizer<MeterRegistry> geboCommonMetricsTags(Environment environment,
+			@Autowired(required = false) GeboApplicationArchitecture architecture) {
+		String applicationName = environment.getProperty("spring.application.name", "gebo-ai");
+		String architectureTag = architecture != null ? architecture.getArchitecture().name().toLowerCase()
+				: "unknown";
+		return registry -> registry.config().commonTags("application", applicationName, "architecture",
+				architectureTag);
+	}
+
+	@Bean
+	public ObservedAspect observedAspect(ObservationRegistry observationRegistry) {
+		return new ObservedAspect(observationRegistry);
+	}
+}

--- a/gebo.architecture.parent/gebo.architecture.telemetry/src/main/java/ai/gebo/architecture/telemetry/MessageBrokerObservabilityAspect.java
+++ b/gebo.architecture.parent/gebo.architecture.telemetry/src/main/java/ai/gebo/architecture/telemetry/MessageBrokerObservabilityAspect.java
@@ -1,0 +1,100 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.architecture.telemetry;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+import ai.gebo.application.messaging.model.GMessageEnvelope;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+
+/**
+ * Instruments {@code IGMessageBroker.accept(..)}/{@code broadcast(..)} -
+ * the single method every message hop passes through, whether it's a local
+ * dispatch inside the monolith, a local dispatch inside a microservice, or
+ * the entry point for a RabbitMQ-delivered envelope. {@code IGMessageBroker}
+ * is a genuine Spring bean injected by interface everywhere it's used, so a
+ * proxy-based AOP aspect reaches every one of those call sites.
+ *
+ * <p>
+ * If the envelope already carries a trace context (populated by
+ * {@link TracingMessageEnvelopeFactory} at creation time, or by a remote
+ * sender before the RabbitMQ hop), this continues that trace; otherwise it
+ * starts a new one. Either way it records a span plus a routing-latency timer
+ * tagged by source/target module and payload type.
+ * </p>
+ */
+@Aspect
+@Component
+@ConditionalOnBean(Tracer.class)
+public class MessageBrokerObservabilityAspect {
+
+	private final Tracer tracer;
+	private final Propagator propagator;
+	private final MeterRegistry meterRegistry;
+
+	public MessageBrokerObservabilityAspect(Tracer tracer, Propagator propagator, MeterRegistry meterRegistry) {
+		this.tracer = tracer;
+		this.propagator = propagator;
+		this.meterRegistry = meterRegistry;
+	}
+
+	@Around("execution(* ai.gebo.application.messaging.IGMessageBroker.accept(..)) "
+			+ "|| execution(* ai.gebo.application.messaging.IGMessageBroker.broadcast(..))")
+	public Object aroundBrokerRouting(ProceedingJoinPoint pjp) throws Throwable {
+		Object[] args = pjp.getArgs();
+		if (args.length == 0 || !(args[0] instanceof GMessageEnvelope<?> envelope)) {
+			return pjp.proceed();
+		}
+
+		String sourceModule = String.valueOf(envelope.getSourceModule());
+		String targetModule = String.valueOf(envelope.getTargetModule());
+		String payloadType = String.valueOf(envelope.getPayloadType());
+
+		Map<String, String> traceContext = envelope.getTraceContext();
+		Span span = (traceContext != null && !traceContext.isEmpty())
+				? propagator.extract(traceContext, Map::get).name(spanName(envelope)).start()
+				: tracer.nextSpan().name(spanName(envelope)).start();
+		span.tag("payloadType", payloadType);
+		span.tag("sourceModule", sourceModule);
+		span.tag("targetModule", targetModule);
+		if (envelope.getWorkflowId() != null) {
+			span.tag("workflowId", envelope.getWorkflowId());
+		}
+		if (envelope.getWorkflowStepId() != null) {
+			span.tag("workflowStepId", envelope.getWorkflowStepId());
+		}
+
+		long start = System.nanoTime();
+		try (Tracer.SpanInScope scope = tracer.withSpan(span)) {
+			return pjp.proceed();
+		} finally {
+			span.end();
+			Timer.builder("gebo.messaging.broker.routing").tag("sourceModule", sourceModule)
+					.tag("targetModule", targetModule).tag("payloadType", payloadType).register(meterRegistry)
+					.record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+		}
+	}
+
+	private String spanName(GMessageEnvelope<?> envelope) {
+		return "gebo.messaging.route." + envelope.getSourceModule() + "." + envelope.getSourceComponent() + "->"
+				+ envelope.getTargetModule() + "." + envelope.getTargetComponent();
+	}
+}

--- a/gebo.architecture.parent/gebo.architecture.telemetry/src/main/java/ai/gebo/architecture/telemetry/TracingMessageDeliveryObserver.java
+++ b/gebo.architecture.parent/gebo.architecture.telemetry/src/main/java/ai/gebo/architecture/telemetry/TracingMessageDeliveryObserver.java
@@ -1,0 +1,66 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.architecture.telemetry;
+
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import ai.gebo.application.messaging.orchestration.IGMessageDeliveryObserver;
+import ai.gebo.application.messaging.model.GMessageEnvelope;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+
+/**
+ * Tracing-aware {@link IGMessageDeliveryObserver}: the actual receiver
+ * execution point - {@code MessageReceiverRunner}'s dedicated-thread delivery
+ * loop and {@code ThreadMessageReceiverMultiplexer}'s synchronous backup path,
+ * neither of which a Spring AOP proxy can reach since both run on manually
+ * managed threads outside the container. Extracts the envelope's trace
+ * context (injected earlier by {@link TracingMessageEnvelopeFactory}) and
+ * scopes a span around the real delivery call, so processing latency and span
+ * nesting are correct regardless of which of the two delivery paths ran.
+ */
+@Component
+@ConditionalOnBean(Tracer.class)
+@Primary
+public class TracingMessageDeliveryObserver implements IGMessageDeliveryObserver {
+
+	private final Tracer tracer;
+	private final Propagator propagator;
+
+	public TracingMessageDeliveryObserver(Tracer tracer, Propagator propagator) {
+		this.tracer = tracer;
+		this.propagator = propagator;
+	}
+
+	@Override
+	public void aroundDelivery(GMessageEnvelope<?> envelope, Runnable delivery) {
+		Map<String, String> traceContext = envelope.getTraceContext();
+		if (traceContext == null || traceContext.isEmpty()) {
+			delivery.run();
+			return;
+		}
+		Span span = propagator.extract(traceContext, Map::get)
+				.name("gebo.messaging.delivery." + envelope.getTargetModule() + "." + envelope.getTargetComponent())
+				.tag("payloadType", String.valueOf(envelope.getPayloadType()))
+				.tag("sourceModule", String.valueOf(envelope.getSourceModule()))
+				.tag("targetModule", String.valueOf(envelope.getTargetModule()))
+				.start();
+		try (Tracer.SpanInScope scope = tracer.withSpan(span)) {
+			delivery.run();
+		} finally {
+			span.end();
+		}
+	}
+}

--- a/gebo.architecture.parent/gebo.architecture.telemetry/src/main/java/ai/gebo/architecture/telemetry/TracingMessageEnvelopeFactory.java
+++ b/gebo.architecture.parent/gebo.architecture.telemetry/src/main/java/ai/gebo/architecture/telemetry/TracingMessageEnvelopeFactory.java
@@ -1,0 +1,73 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.architecture.telemetry;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import ai.gebo.application.messaging.IGMessageEmitter;
+import ai.gebo.application.messaging.IGMessagePayloadType;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
+import ai.gebo.application.messaging.impl.DefaultMessageEnvelopeFactory;
+import ai.gebo.application.messaging.model.GMessageEnvelope;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+
+/**
+ * Tracing-aware {@link IMessageEnvelopeFactory}: builds the envelope exactly
+ * as {@link DefaultMessageEnvelopeFactory} does, then injects the current
+ * trace context (if any) into it via Micrometer Tracing's {@link Propagator}.
+ * Because {@code GMessageEnvelopeCodec} round-trips the whole envelope as
+ * JSON, this trace context survives the RabbitMQ hop automatically - no AMQP
+ * header plumbing is involved. Active only when a {@link Tracer} bean exists
+ * (i.e. {@code gebo.architecture.telemetry} is on the classpath); takes
+ * priority over {@link DefaultMessageEnvelopeFactory} via {@code @Primary}.
+ */
+@Component
+@ConditionalOnBean(Tracer.class)
+@Primary
+public class TracingMessageEnvelopeFactory implements IMessageEnvelopeFactory {
+
+	private final DefaultMessageEnvelopeFactory delegate;
+	private final Tracer tracer;
+	private final Propagator propagator;
+
+	public TracingMessageEnvelopeFactory(DefaultMessageEnvelopeFactory delegate, Tracer tracer,
+			Propagator propagator) {
+		this.delegate = delegate;
+		this.tracer = tracer;
+		this.propagator = propagator;
+	}
+
+	@Override
+	public <T extends IGMessagePayloadType> GMessageEnvelope<T> newMessageFrom(IGMessageEmitter system, T payload) {
+		GMessageEnvelope<T> envelope = delegate.newMessageFrom(system, payload);
+		injectTraceContext(envelope);
+		return envelope;
+	}
+
+	@Override
+	public <T extends IGMessagePayloadType> GMessageEnvelope<T> newMessageFrom(IGMessageEmitter system, T payload,
+			String user) {
+		GMessageEnvelope<T> envelope = delegate.newMessageFrom(system, payload, user);
+		injectTraceContext(envelope);
+		return envelope;
+	}
+
+	private void injectTraceContext(GMessageEnvelope<?> envelope) {
+		Span currentSpan = tracer.currentSpan();
+		if (currentSpan == null || currentSpan.isNoop()) {
+			return;
+		}
+		propagator.inject(currentSpan.context(), envelope, GMessageEnvelope::putTraceContextField);
+	}
+}

--- a/gebo.architecture.parent/pom.xml
+++ b/gebo.architecture.parent/pom.xml
@@ -34,6 +34,7 @@
   	<module>gebo.restintegration.abstraction.layer</module>
   	<module>gebo.architecture.crypting</module>
   	<module>gebo.architecture.environment</module>
+  	<module>gebo.architecture.telemetry</module>
   	<module>gebo.architecture.testing</module>
   	<module>gebo.architecture.integration.tests</module>
 

--- a/gebo.core.parent/gebo.core/src/main/java/ai/gebo/core/impl/GComputeEndOfWorkflowReceiverFactory.java
+++ b/gebo.core.parent/gebo.core/src/main/java/ai/gebo/core/impl/GComputeEndOfWorkflowReceiverFactory.java
@@ -12,6 +12,7 @@ import ai.gebo.application.messaging.GAbstractMessageReceiverFactory;
 import ai.gebo.application.messaging.IGMessageBroker;
 import ai.gebo.application.messaging.IGMessageEmitter;
 import ai.gebo.application.messaging.IGMessageReceiver;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
 import ai.gebo.application.messaging.SystemComponentType;
 import ai.gebo.application.messaging.model.GMessageEnvelope;
 import ai.gebo.application.messaging.model.GStandardModulesConstraints;
@@ -29,6 +30,7 @@ import lombok.AllArgsConstructor;
 
 public class GComputeEndOfWorkflowReceiverFactory extends GAbstractMessageReceiverFactory {
 	private final IGRuntimeBinder runtimeBinder;
+	private final IMessageEnvelopeFactory envelopeFactory;
 	public static final String END_OF_WORKFLOW_COMPUTE_SERVICE = "end-of-workflow-compute-service";
 	public static final MessageReceiverFactoryConfig factoryConfig = new MessageReceiverFactoryConfig();
 	private static final Logger LOGGER = LoggerFactory.getLogger(GComputeEndOfWorkflowReceiverFactory.class);
@@ -58,7 +60,7 @@ public class GComputeEndOfWorkflowReceiverFactory extends GAbstractMessageReceiv
 						finishedWorkflow.setWorkflowId(payload.getWorkflowId());
 						IGMessageEmitter emitter = runtimeBinder.getImplementationOf(GCoreMessagesEmitterImpl.class);
 						IGMessageBroker broker = runtimeBinder.getImplementationOf(IGMessageBroker.class);
-						GMessageEnvelope<GFinishedWorkflowPayload> envelope = GMessageEnvelope.newMessageFrom(emitter,
+						GMessageEnvelope<GFinishedWorkflowPayload> envelope = envelopeFactory.newMessageFrom(emitter,
 								finishedWorkflow);
 						broker.broadcast(envelope);
 					}
@@ -68,9 +70,10 @@ public class GComputeEndOfWorkflowReceiverFactory extends GAbstractMessageReceiv
 
 	}
 
-	public GComputeEndOfWorkflowReceiverFactory(IGRuntimeBinder runtimeBinder) {
+	public GComputeEndOfWorkflowReceiverFactory(IGRuntimeBinder runtimeBinder, IMessageEnvelopeFactory envelopeFactory) {
 		super(factoryConfig);
 		this.runtimeBinder = runtimeBinder;
+		this.envelopeFactory = envelopeFactory;
 	}
 
 	@Override

--- a/gebo.core.parent/gebo.core/src/main/java/ai/gebo/core/impl/GCoreMessagesEmitterImpl.java
+++ b/gebo.core.parent/gebo.core/src/main/java/ai/gebo/core/impl/GCoreMessagesEmitterImpl.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 import ai.gebo.application.messaging.IGMessageBroker;
 import ai.gebo.application.messaging.IGMessageEmitter;
 import ai.gebo.application.messaging.IGMessagePayloadType;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
 import ai.gebo.application.messaging.SystemComponentType;
 import ai.gebo.application.messaging.model.ComponentMetaInfo;
 import ai.gebo.application.messaging.model.GMessageEnvelope;
@@ -45,6 +46,8 @@ public class GCoreMessagesEmitterImpl implements IGMessageEmitter {
 	IGSecurityService securityService; // Security service for retrieving user information.
 	@Autowired
 	ProjectRepository projectsRepo; // Repository for accessing project data.
+	@Autowired
+	IMessageEnvelopeFactory envelopeFactory;
 
 	/**
 	 * Constructor for GCoreMessagesEmitterImpl. Initializes the component.
@@ -133,7 +136,7 @@ public class GCoreMessagesEmitterImpl implements IGMessageEmitter {
 		List<ComponentMetaInfo> systems = broker
 				.getComponentsByMessagingSystemId(GStandardModulesConstraints.RESOURCES_DISPOSE_COMPONENT);
 		for (ComponentMetaInfo componentMetaInfo : systems) {
-			GMessageEnvelope msg = GMessageEnvelope.newMessageFrom(this, payload, user);
+			GMessageEnvelope msg = envelopeFactory.newMessageFrom(this, payload, user);
 			msg.setTargetModule(componentMetaInfo.getMessagingModuleId());
 			msg.setTargetComponent(componentMetaInfo.getMessagingSystemId());
 			broker.accept(msg);
@@ -147,7 +150,7 @@ public class GCoreMessagesEmitterImpl implements IGMessageEmitter {
 	 */
 	protected void sendDeletingPayloadToCoreMongoDocuments(IGMessagePayloadType payload) {
 		String user = securityService.getCurrentUser().getUsername(); // Retrieve current user's username.
-		GMessageEnvelope msg = GMessageEnvelope.newMessageFrom(this, payload, user);
+		GMessageEnvelope msg = envelopeFactory.newMessageFrom(this, payload, user);
 		msg.setTargetModule(GStandardModulesConstraints.CORE_MODULE);
 		msg.setTargetComponent(GStandardModulesConstraints.MONGO_DISPOSE_DOCUMENTS_COMPONENT);
 		broker.accept(msg);
@@ -160,7 +163,7 @@ public class GCoreMessagesEmitterImpl implements IGMessageEmitter {
 	 */
 	protected void sendDeletingPayloadToVectorizator(IGMessagePayloadType payload) {
 		String user = securityService.getCurrentUser().getUsername(); // Retrieve current user's username.
-		GMessageEnvelope msg = GMessageEnvelope.newMessageFrom(this, payload, user);
+		GMessageEnvelope msg = envelopeFactory.newMessageFrom(this, payload, user);
 		msg.setTargetModule(GStandardModulesConstraints.VECTORIZATOR_MODULE);
 		msg.setTargetComponent(GStandardModulesConstraints.VECTORIZATION_DISPOSE_COMPONENT);
 		broker.accept(msg);

--- a/gebo.llms.parent/gebo.llms.anthropic3/src/main/java/ai/gebo/llms/anthropic/services/AnthropicChatModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.anthropic3/src/main/java/ai/gebo/llms/anthropic/services/AnthropicChatModelConfigurationSupportService.java
@@ -97,6 +97,7 @@ public class AnthropicChatModelConfigurationSupportService
 	final IGDocumentContentRendererProvider documentContentRenderProvider;
 
 	final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Inner class that implements the configurable chat model for Anthropic
@@ -105,9 +106,9 @@ public class AnthropicChatModelConfigurationSupportService
 			extends GAbstractConfigurableChatModel<GAnthropicChatModelConfig, AnthropicChatModel> {
 
 		public AnthropicConfigurableChatModel(IGDocumentContentRendererProvider rendererFactory,
-				IGToolCallbackSourceRepositoryPattern toolCallbacksRepository, IChatModelUsageAdvisorFactory usageAdvisorFactory) {
-			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
-			// TODO Auto-generated constructor stub
+				IGToolCallbackSourceRepositoryPattern toolCallbacksRepository,
+				IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
+			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 		}
 
 		/**
@@ -168,7 +169,7 @@ public class AnthropicChatModelConfigurationSupportService
 			AnthropicChatModel model = AnthropicChatModel.builder()
 					.options(anthropicChatOptions)
 					.toolCallingManager(toolCallingManager)
-					.observationRegistry(ObservationRegistry.create())
+					.observationRegistry(observationRegistry)
 					.httpClientBuilderCustomizer(AnthropicClientCustomizer.from(clientsProvider))
 					.build();
 			return model;
@@ -177,7 +178,7 @@ public class AnthropicChatModelConfigurationSupportService
 		@Override
 		protected IGConfigurableChatModel cloneMeWithInjection() {
 			AnthropicConfigurableChatModel anthropicChatModel = new AnthropicConfigurableChatModel(rendererFactory,
-					toolCallbacksRepository, usageAdvisorFactory);
+					toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 			return anthropicChatModel;
 		}
 	}
@@ -203,7 +204,7 @@ public class AnthropicChatModelConfigurationSupportService
 	public IGConfigurableChatModel<GAnthropicChatModelConfig> create(GAnthropicChatModelConfig config)
 			throws LLMConfigException {
 		AnthropicConfigurableChatModel model = new AnthropicConfigurableChatModel(this.documentContentRenderProvider,
-				functionsRepo, usageAdvisorFactory);
+				functionsRepo, usageAdvisorFactory, observationRegistry);
 		model.initialize(config, type);
 		return model;
 	}

--- a/gebo.llms.parent/gebo.llms.aws-bedrock/src/main/java/ai/gebo/llms/aws_bedrock/services/BedrockChatModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.aws-bedrock/src/main/java/ai/gebo/llms/aws_bedrock/services/BedrockChatModelConfigurationSupportService.java
@@ -63,14 +63,15 @@ public class BedrockChatModelConfigurationSupportService
 	final ModelRuntimeConfigureHandler configureHandler;
 	final IGDocumentContentRendererProvider documentContentRenderProvider;
 	final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	final ObservationRegistry observationRegistry;
 
 	class BedrockConfigurableChatModel
 			extends GAbstractConfigurableChatModel<GBedrockChatModelConfig, BedrockProxyChatModel> {
 
 		public BedrockConfigurableChatModel(IGDocumentContentRendererProvider rendererFactory,
 				IGToolCallbackSourceRepositoryPattern toolCallbacksRepository,
-				IChatModelUsageAdvisorFactory usageAdvisorFactory) {
-			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+				IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
+			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 		}
 
 		@Override
@@ -107,7 +108,7 @@ public class BedrockChatModelConfigurationSupportService
 					.region(region)
 					.options(options)
 					.toolCallingManager(toolCallingManager)
-					.observationRegistry(ObservationRegistry.NOOP)
+					.observationRegistry(observationRegistry)
 					.build();
 		}
 
@@ -118,7 +119,8 @@ public class BedrockChatModelConfigurationSupportService
 
 		@Override
 		protected IGConfigurableChatModel cloneMeWithInjection() {
-			return new BedrockConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+			return new BedrockConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory,
+					observationRegistry);
 		}
 	}
 
@@ -131,7 +133,7 @@ public class BedrockChatModelConfigurationSupportService
 	public IGConfigurableChatModel<GBedrockChatModelConfig> create(GBedrockChatModelConfig config)
 			throws LLMConfigException {
 		BedrockConfigurableChatModel model = new BedrockConfigurableChatModel(documentContentRenderProvider,
-				functionsRepo, usageAdvisorFactory);
+				functionsRepo, usageAdvisorFactory, observationRegistry);
 		model.initialize(config, type);
 		return model;
 	}

--- a/gebo.llms.parent/gebo.llms.aws-bedrock/src/main/java/ai/gebo/llms/aws_bedrock/services/BedrockEmbeddingModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.aws-bedrock/src/main/java/ai/gebo/llms/aws_bedrock/services/BedrockEmbeddingModelConfigurationSupportService.java
@@ -64,12 +64,13 @@ public class BedrockEmbeddingModelConfigurationSupportService implements
 	final BedrockFoundationModelsLookupService modelsLookupService;
 	final IGVectorStoreFactoryProvider storeFactoryProvider;
 	final ModelRuntimeConfigureHandler configureHandler;
+	final ObservationRegistry observationRegistry;
 
 	class BedrockConfigurableEmbeddingModel
 			extends GAbstractConfigurableEmbeddingModel<GBedrockEmbeddingModelConfig, EmbeddingModel> {
 
 		public BedrockConfigurableEmbeddingModel() {
-			super(storeFactoryProvider);
+			super(storeFactoryProvider, BedrockEmbeddingModelConfigurationSupportService.this.observationRegistry);
 		}
 
 		@Override
@@ -86,12 +87,14 @@ public class BedrockEmbeddingModelConfigurationSupportService implements
 			if (modelId.startsWith("cohere.")) {
 				CohereEmbeddingBedrockApi api = new CohereEmbeddingBedrockApi(modelId, credentials, region, jsonMapper,
 						API_TIMEOUT);
+				// BedrockCohereEmbeddingModel has no ObservationRegistry-accepting constructor
+				// in this Spring AI version - only the Titan path below can be wired.
 				return new BedrockCohereEmbeddingModel(api);
 			}
 			// Amazon Titan embeddings (amazon.titan-embed-*) and default fallback
 			TitanEmbeddingBedrockApi api = new TitanEmbeddingBedrockApi(modelId, credentials, region, jsonMapper,
 					API_TIMEOUT);
-			return new BedrockTitanEmbeddingModel(api, ObservationRegistry.NOOP);
+			return new BedrockTitanEmbeddingModel(api, observationRegistry);
 		}
 	}
 

--- a/gebo.llms.parent/gebo.llms.deepseek/src/main/java/ai/gebo/llms/deepseek/services/DeepseekChatModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.deepseek/src/main/java/ai/gebo/llms/deepseek/services/DeepseekChatModelConfigurationSupportService.java
@@ -92,6 +92,7 @@ public class DeepseekChatModelConfigurationSupportService
 	final ModelRuntimeConfigureHandler configureHandler;
 	final IGDocumentContentRendererProvider documentContentRenderProvider;
 	final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Implementation of configurable chat model for DeepSeek Note: The class is
@@ -103,8 +104,8 @@ public class DeepseekChatModelConfigurationSupportService
 
 		public DeepseekConfigurableChatModel(IGDocumentContentRendererProvider rendererFactory,
 				IGToolCallbackSourceRepositoryPattern toolCallbacksRepository,
-				IChatModelUsageAdvisorFactory usageAdvisorFactory) {
-			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+				IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
+			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 
 		    }
 
@@ -175,14 +176,15 @@ public class DeepseekChatModelConfigurationSupportService
 					: functionsRepo.createToolCallingManager();
 
 			DeepSeekChatModel model = new DeepSeekChatModel(deepseekApi, deepseekChatOptions, toolCallingManager,
-					retryTemplate, ObservationRegistry.create());
+					retryTemplate, observationRegistry);
 			return model;
 		}
 
 		@Override
 		protected IGConfigurableChatModel cloneMeWithInjection() {
 
-			return new DeepseekConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+			return new DeepseekConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory,
+					observationRegistry);
 		}
 	};
 
@@ -207,7 +209,7 @@ public class DeepseekChatModelConfigurationSupportService
 	public IGConfigurableChatModel<GDeepseekChatModelConfig> create(GDeepseekChatModelConfig config)
 			throws LLMConfigException {
 		DeepseekConfigurableChatModel model = new DeepseekConfigurableChatModel(documentContentRenderProvider,
-				functionsRepo, usageAdvisorFactory);
+				functionsRepo, usageAdvisorFactory, observationRegistry);
 		model.initialize(config, type);
 		return model;
 	}

--- a/gebo.llms.parent/gebo.llms.generic-openai-compatible/src/main/java/ai/gebo/llms/openai_compat/config/GenericOpenAIProvidersAssembler.java
+++ b/gebo.llms.parent/gebo.llms.generic-openai-compatible/src/main/java/ai/gebo/llms/openai_compat/config/GenericOpenAIProvidersAssembler.java
@@ -48,6 +48,7 @@ import ai.gebo.llms.openai_compat.services.GenericOpenAIAPITranscriptModelConfig
 import ai.gebo.llms.openai_compat.services.GenericOpenAIAPIRankerModelConfigurationSupportService;
 import ai.gebo.llms.openai_compat.services.ModelsListProviderProxyService;
 import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.PostConstruct;
 import lombok.AllArgsConstructor;
 
@@ -109,6 +110,7 @@ public class GenericOpenAIProvidersAssembler {
 	final ILLMTypeFiltrerRepositoryPattern llmTypeFiltrerRepoPattern;
 	final IGDocumentContentRendererProvider documentsContentRendererProvider;
 	final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Initializes and registers all configured OpenAI-compatible providers. This
@@ -123,7 +125,7 @@ public class GenericOpenAIProvidersAssembler {
 				GenericOpenAIAPIChatModelConfigurationSupportService provider = new GenericOpenAIAPIChatModelConfigurationSupportService(
 						pc, secretService, openaiApiUtil, functionsRepo, modelsListProxyService,
 						serviceClientsProviderFactory, configureHandler, llmTypeFiltrerRepoPattern,
-						documentsContentRendererProvider, usageAdvisorFactory);
+						documentsContentRendererProvider, usageAdvisorFactory, observationRegistry);
 				chatModelProvidersRepo.addImplementation(provider);
 			}
 		}
@@ -133,7 +135,7 @@ public class GenericOpenAIProvidersAssembler {
 			for (GenericOpenAIEmbeddingModelTypeConfig pc : config.getEmbeddingModelProviders()) {
 				GenericOpenAIAPIEmbeddingModelConfigurationSupportService provider = new GenericOpenAIAPIEmbeddingModelConfigurationSupportService(
 						pc, secretService, openaiApiUtil, functionsRepo, storeFactoryProvider, modelsListProxyService,
-						serviceClientsProviderFactory, configureHandler, llmTypeFiltrerRepoPattern);
+						serviceClientsProviderFactory, configureHandler, llmTypeFiltrerRepoPattern, observationRegistry);
 				embeddingModelProvidersRepo.addImplementation(provider);
 			}
 		}

--- a/gebo.llms.parent/gebo.llms.generic-openai-compatible/src/main/java/ai/gebo/llms/openai_compat/services/GenericOpenAIAPIChatModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.generic-openai-compatible/src/main/java/ai/gebo/llms/openai_compat/services/GenericOpenAIAPIChatModelConfigurationSupportService.java
@@ -90,10 +90,11 @@ public class GenericOpenAIAPIChatModelConfigurationSupportService implements
 	final ILLMTypeFiltrerRepositoryPattern llmTypeFiltrerRepoPattern;
 	final IGDocumentContentRendererProvider documentContentRenderProvider;
 	final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Constructor that initializes all required dependencies
-	 * 
+	 *
 	 * @param type                          The configuration for the
 	 *                                      OpenAI-compatible model type
 	 * @param secretService                 Service for accessing API keys and other
@@ -109,7 +110,7 @@ public class GenericOpenAIAPIChatModelConfigurationSupportService implements
 			IGLlmsServiceClientsProviderFactory serviceClientsProviderFactory,
 			ModelRuntimeConfigureHandler configureHandler, ILLMTypeFiltrerRepositoryPattern llmTypeFiltrerRepoPattern,
 			IGDocumentContentRendererProvider documentContentRenderProvider,
-			IChatModelUsageAdvisorFactory usageAdvisorFactory) {
+			IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
 		this.type = type;
 		this.secretService = secretService;
 		this.functionsRepo = functionsRepo;
@@ -120,6 +121,7 @@ public class GenericOpenAIAPIChatModelConfigurationSupportService implements
 		this.llmTypeFiltrerRepoPattern = llmTypeFiltrerRepoPattern;
 		this.documentContentRenderProvider = documentContentRenderProvider;
 		this.usageAdvisorFactory = usageAdvisorFactory;
+		this.observationRegistry = observationRegistry;
 
 	}
 
@@ -132,8 +134,8 @@ public class GenericOpenAIAPIChatModelConfigurationSupportService implements
 
 		public GenericOpenAIConfigurableChatModel(IGDocumentContentRendererProvider rendererFactory,
 				IGToolCallbackSourceRepositoryPattern toolCallbacksRepository,
-				IChatModelUsageAdvisorFactory usageAdvisorFactory) {
-			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+				IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
+			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 
 		}
 
@@ -211,7 +213,7 @@ public class GenericOpenAIAPIChatModelConfigurationSupportService implements
 			OpenAiChatModel model = OpenAiChatModel.builder()
 					.options(options)
 					.toolCallingManager(toolCallingManager)
-					.observationRegistry(ObservationRegistry.create())
+					.observationRegistry(observationRegistry)
 					.httpClientBuilderCustomizer(OpenAiClientCustomizer.from(clientsProvider))
 					.build();
 			return model;
@@ -274,7 +276,8 @@ public class GenericOpenAIAPIChatModelConfigurationSupportService implements
 		@Override
 		protected IGConfigurableChatModel cloneMeWithInjection() {
 
-			return new GenericOpenAIConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+			return new GenericOpenAIConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory,
+					observationRegistry);
 		}
 	};
 
@@ -299,7 +302,7 @@ public class GenericOpenAIAPIChatModelConfigurationSupportService implements
 	public IGConfigurableChatModel<GenericOpenAIAPIChatModelConfig> create(GenericOpenAIAPIChatModelConfig config)
 			throws LLMConfigException {
 		GenericOpenAIConfigurableChatModel model = new GenericOpenAIConfigurableChatModel(documentContentRenderProvider,
-				functionsRepo, usageAdvisorFactory);
+				functionsRepo, usageAdvisorFactory, observationRegistry);
 		model.initialize(config, type);
 		return model;
 	}

--- a/gebo.llms.parent/gebo.llms.generic-openai-compatible/src/main/java/ai/gebo/llms/openai_compat/services/GenericOpenAIAPIEmbeddingModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.generic-openai-compatible/src/main/java/ai/gebo/llms/openai_compat/services/GenericOpenAIAPIEmbeddingModelConfigurationSupportService.java
@@ -45,6 +45,7 @@ import ai.gebo.secrets.model.AbstractGeboSecretContent;
 import ai.gebo.secrets.model.GeboSecretType;
 import ai.gebo.secrets.model.GeboTokenContent;
 import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import io.micrometer.observation.ObservationRegistry;
 
 /**
  * AI generated comments
@@ -71,6 +72,7 @@ public class GenericOpenAIAPIEmbeddingModelConfigurationSupportService implement
 	final IGLlmsServiceClientsProviderFactory serviceClientsProviderFactory;
 	final ModelRuntimeConfigureHandler configureHandler;
 	final ILLMTypeFiltrerRepositoryPattern llmTypeFiltrerRepoPattern;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Constructor initializing the service with required dependencies.
@@ -88,7 +90,8 @@ public class GenericOpenAIAPIEmbeddingModelConfigurationSupportService implement
 			IGToolCallbackSourceRepositoryPattern functionsRepo, IGVectorStoreFactoryProvider storeFactoryProvider,
 			ModelsListProviderProxyService modelsListProxyService,
 			IGLlmsServiceClientsProviderFactory serviceClientsProviderFactory,
-			ModelRuntimeConfigureHandler configureHandler, ILLMTypeFiltrerRepositoryPattern llmTypeFiltrerRepoPattern) {
+			ModelRuntimeConfigureHandler configureHandler, ILLMTypeFiltrerRepositoryPattern llmTypeFiltrerRepoPattern,
+			ObservationRegistry observationRegistry) {
 		this.type = type;
 		this.secretService = secretService;
 		this.functionsRepo = functionsRepo;
@@ -98,6 +101,7 @@ public class GenericOpenAIAPIEmbeddingModelConfigurationSupportService implement
 		this.serviceClientsProviderFactory = serviceClientsProviderFactory;
 		this.configureHandler = configureHandler;
 		this.llmTypeFiltrerRepoPattern = llmTypeFiltrerRepoPattern;
+		this.observationRegistry = observationRegistry;
 	}
 
 	/**
@@ -113,7 +117,8 @@ public class GenericOpenAIAPIEmbeddingModelConfigurationSupportService implement
 		 * provider.
 		 */
 		public GenericOpenAIConfigurableEmbeddingModel() {
-			super(storeFactoryProvider);
+			super(storeFactoryProvider,
+					GenericOpenAIAPIEmbeddingModelConfigurationSupportService.this.observationRegistry);
 
 		}
 
@@ -169,6 +174,7 @@ public class GenericOpenAIAPIEmbeddingModelConfigurationSupportService implement
 			OpenAiEmbeddingModel model = OpenAiEmbeddingModel.builder()
 					.options(options)
 					.metadataMode(MetadataMode.EMBED)
+					.observationRegistry(observationRegistry)
 					.httpClientBuilderCustomizer(OpenAiClientCustomizer.from(clientsProvider))
 					.build();
 			return model;

--- a/gebo.llms.parent/gebo.llms.google_vertex/src/main/java/ai/gebo/llms/google_vertex/services/GoogleVertexChatModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.google_vertex/src/main/java/ai/gebo/llms/google_vertex/services/GoogleVertexChatModelConfigurationSupportService.java
@@ -81,6 +81,7 @@ public class GoogleVertexChatModelConfigurationSupportService
 	final ILLMTypeFiltrerRepositoryPattern llmTypeFiltrerRepoPattern;
 	final IGDocumentContentRendererProvider documentContentRenderProvider;
 	final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Inner class that handles the configuration and initialization of Google
@@ -91,8 +92,8 @@ public class GoogleVertexChatModelConfigurationSupportService
 
 		public GoogleVertexConfigurableChatModel(IGDocumentContentRendererProvider rendererFactory,
 				IGToolCallbackSourceRepositoryPattern toolCallbacksRepository,
-				IChatModelUsageAdvisorFactory usageAdvisorFactory) {
-			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+				IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
+			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 
 		}
 
@@ -138,7 +139,7 @@ public class GoogleVertexChatModelConfigurationSupportService
 					.options(options)
 					.toolCallingManager(
 							toolsCallsManager != null ? toolsCallsManager : functionsRepo.createToolCallingManager())
-					.observationRegistry(ObservationRegistry.create())
+					.observationRegistry(observationRegistry)
 					.build();
 			return model;
 		}
@@ -146,7 +147,8 @@ public class GoogleVertexChatModelConfigurationSupportService
 		@Override
 		protected IGConfigurableChatModel cloneMeWithInjection() {
 
-			return new GoogleVertexConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+			return new GoogleVertexConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory,
+					observationRegistry);
 		}
 	};
 
@@ -171,7 +173,7 @@ public class GoogleVertexChatModelConfigurationSupportService
 	public IGConfigurableChatModel<GGoogleVertexChatModelConfig> create(GGoogleVertexChatModelConfig config)
 			throws LLMConfigException {
 		GoogleVertexConfigurableChatModel model = new GoogleVertexConfigurableChatModel(documentContentRenderProvider,
-				functionsRepo, usageAdvisorFactory);
+				functionsRepo, usageAdvisorFactory, observationRegistry);
 		model.initialize(config, type);
 		return model;
 	}

--- a/gebo.llms.parent/gebo.llms.google_vertex/src/main/java/ai/gebo/llms/google_vertex/services/GoogleVertexEmbeddingModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.google_vertex/src/main/java/ai/gebo/llms/google_vertex/services/GoogleVertexEmbeddingModelConfigurationSupportService.java
@@ -36,6 +36,7 @@ import ai.gebo.secrets.model.GeboTokenContent;
 import ai.gebo.architecture.persistence.GeboPersistenceException;
 import ai.gebo.crypting.services.GeboCryptSecretException;
 import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.AllArgsConstructor;
 
 /**
@@ -77,6 +78,7 @@ public class GoogleVertexEmbeddingModelConfigurationSupportService implements
 	final VertexAIConfigurator configurator;
 	final ModelRuntimeConfigureHandler configureHandler;
 	final ILLMTypeFiltrerRepositoryPattern llmTypeFiltrerRepoPattern;
+	final ObservationRegistry observationRegistry;
 	/**
 	 * Inner class that implements a configurable Google Vertex embedding model.
 	 */
@@ -85,11 +87,12 @@ public class GoogleVertexEmbeddingModelConfigurationSupportService implements
 
 		/**
 		 * Constructor for the embedding model.
-		 * 
+		 *
 		 * @throws LLMConfigException if there's an issue with the model configuration
 		 */
 		public GoogleVertexConfigurableEmbeddingModel() throws LLMConfigException {
-			super(GoogleVertexEmbeddingModelConfigurationSupportService.this.vectorStoreFactoryProvider);
+			super(GoogleVertexEmbeddingModelConfigurationSupportService.this.vectorStoreFactoryProvider,
+					GoogleVertexEmbeddingModelConfigurationSupportService.this.observationRegistry);
 
 		}
 
@@ -114,7 +117,8 @@ public class GoogleVertexEmbeddingModelConfigurationSupportService implements
 			VertexAiEmbeddingConnectionDetails connectionDetails = configurator
 					.createVertexAiEmbeddingConnectionDetails(config.getApiSecretCode(), config.getBaseUrl());
 			VertexAiTextEmbeddingOptions options = oBuilder.build();
-			VertexAiTextEmbeddingModel model = new VertexAiTextEmbeddingModel(connectionDetails, options);
+			VertexAiTextEmbeddingModel model = new VertexAiTextEmbeddingModel(connectionDetails, options,
+					new org.springframework.core.retry.RetryTemplate(), observationRegistry);
 			return model;
 		}
 

--- a/gebo.llms.parent/gebo.llms.mistral/src/main/java/ai/gebo/llms/mistralai/services/MistralChatModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.mistral/src/main/java/ai/gebo/llms/mistralai/services/MistralChatModelConfigurationSupportService.java
@@ -81,6 +81,7 @@ public class MistralChatModelConfigurationSupportService
 	final ModelRuntimeConfigureHandler configureHandler;
 	final IGDocumentContentRendererProvider documentContentRenderProvider;
 	final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Inner class that implements the configuration and creation of Mistral AI chat
@@ -91,8 +92,8 @@ public class MistralChatModelConfigurationSupportService
 
 		public MistralConfigurableChatModel(IGDocumentContentRendererProvider rendererFactory,
 				IGToolCallbackSourceRepositoryPattern toolCallbacksRepository,
-				IChatModelUsageAdvisorFactory usageAdvisorFactory) {
-			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+				IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
+			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 
 		}
 
@@ -161,7 +162,7 @@ public class MistralChatModelConfigurationSupportService
 					.toolCallingManager(
 							toolsCallsManager != null ? toolsCallsManager : functionsRepo.createToolCallingManager())
 					.retryTemplate(retryTemplate)
-					.observationRegistry(ObservationRegistry.NOOP)
+					.observationRegistry(observationRegistry)
 					.build();
 			return model;
 		}
@@ -190,7 +191,8 @@ public class MistralChatModelConfigurationSupportService
 		@Override
 		protected IGConfigurableChatModel cloneMeWithInjection() {
 
-			return new MistralConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+			return new MistralConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory,
+					observationRegistry);
 		}
 	};
 
@@ -215,7 +217,7 @@ public class MistralChatModelConfigurationSupportService
 	public IGConfigurableChatModel<GMistralChatModelConfig> create(GMistralChatModelConfig config)
 			throws LLMConfigException {
 		MistralConfigurableChatModel model = new MistralConfigurableChatModel(documentContentRenderProvider,
-				functionsRepo, usageAdvisorFactory);
+				functionsRepo, usageAdvisorFactory, observationRegistry);
 		model.initialize(config, type);
 		return model;
 	}

--- a/gebo.llms.parent/gebo.llms.mistral/src/main/java/ai/gebo/llms/mistralai/services/MistralEmbeddingModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.mistral/src/main/java/ai/gebo/llms/mistralai/services/MistralEmbeddingModelConfigurationSupportService.java
@@ -74,6 +74,7 @@ public class MistralEmbeddingModelConfigurationSupportService implements
 	final MistralModelsLookupService mistralModelsLookupService;
 	final IGLlmsServiceClientsProviderFactory serviceClientsProviderFactory;
 	final ModelRuntimeConfigureHandler configureHandler;
+	final ObservationRegistry observationRegistry;
 	/*
 	 * @Autowired IGOpenAIApiUtil openaiApiUtil;
 	 */
@@ -90,7 +91,7 @@ public class MistralEmbeddingModelConfigurationSupportService implements
 		 * provider.
 		 */
 		public MistralConfigurableEmbeddingModel() {
-			super(storeFactoryProvider);
+			super(storeFactoryProvider, MistralEmbeddingModelConfigurationSupportService.this.observationRegistry);
 
 		}
 
@@ -143,7 +144,7 @@ public class MistralEmbeddingModelConfigurationSupportService implements
 			MistralAiEmbeddingOptions options = builder.build();
 			MetadataMode meta = MetadataMode.EMBED;
 			MistralAiEmbeddingModel model = new MistralAiEmbeddingModel(mistralApi, meta, options, retryTemplate,
-					ObservationRegistry.NOOP);
+					observationRegistry);
 			return model;
 		}
 

--- a/gebo.llms.parent/gebo.llms.ollama/src/main/java/ai/gebo/llms/ollama/services/OllamaChatModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.ollama/src/main/java/ai/gebo/llms/ollama/services/OllamaChatModelConfigurationSupportService.java
@@ -95,6 +95,7 @@ public class OllamaChatModelConfigurationSupportService
 	final ModelRuntimeConfigureHandler configureHandler;
 	final IGDocumentContentRendererProvider documentContentRenderProvider;
 	final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Inner class that implements the configurable chat model for Ollama
@@ -103,8 +104,8 @@ public class OllamaChatModelConfigurationSupportService
 
 		public OllamaConfigurableChatModel(IGDocumentContentRendererProvider rendererFactory,
 				IGToolCallbackSourceRepositoryPattern toolCallbacksRepository,
-				IChatModelUsageAdvisorFactory usageAdvisorFactory) {
-			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+				IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
+			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 
 		}
 
@@ -166,7 +167,7 @@ public class OllamaChatModelConfigurationSupportService
 			OllamaChatOptions options = builder.build();
 			OllamaChatModel model = new OllamaChatModel(ollamaapi, options, toolsCallsManager != null ? toolsCallsManager
 					: functionsRepo.createToolCallingManager(),
-					ObservationRegistry.create(), ModelManagementOptions.defaults());
+					observationRegistry, ModelManagementOptions.defaults());
 			return model;
 		}
 
@@ -194,7 +195,8 @@ public class OllamaChatModelConfigurationSupportService
 		@Override
 		protected IGConfigurableChatModel cloneMeWithInjection() {
 
-			return new OllamaConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+			return new OllamaConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory,
+					observationRegistry);
 		}
 	};
 
@@ -220,7 +222,7 @@ public class OllamaChatModelConfigurationSupportService
 	public IGConfigurableChatModel<GOllamaChatModelConfig> create(GOllamaChatModelConfig config)
 			throws LLMConfigException {
 		OllamaConfigurableChatModel model = new OllamaConfigurableChatModel(documentContentRenderProvider,
-				functionsRepo, usageAdvisorFactory);
+				functionsRepo, usageAdvisorFactory, observationRegistry);
 		model.initialize(config, type);
 		return model;
 	}

--- a/gebo.llms.parent/gebo.llms.ollama/src/main/java/ai/gebo/llms/ollama/services/OllamaEmbeddingModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.ollama/src/main/java/ai/gebo/llms/ollama/services/OllamaEmbeddingModelConfigurationSupportService.java
@@ -73,6 +73,7 @@ public class OllamaEmbeddingModelConfigurationSupportService implements
 
 	final IGLlmsServiceClientsProviderFactory serviceClientsProviderFactory;
 	final ModelRuntimeConfigureHandler configureHandler;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Inner class that implements configurable embedding model for Ollama. Handles
@@ -85,7 +86,7 @@ public class OllamaEmbeddingModelConfigurationSupportService implements
 		 * Constructor for the Ollama configurable embedding model.
 		 */
 		public OllamaConfigurableEmbeddingModel() {
-			super(storeFactoryProvider);
+			super(storeFactoryProvider, OllamaEmbeddingModelConfigurationSupportService.this.observationRegistry);
 		}
 
 		/**
@@ -118,7 +119,6 @@ public class OllamaEmbeddingModelConfigurationSupportService implements
 
 			OllamaEmbeddingOptions options = builder.build();
 			MetadataMode meta = MetadataMode.EMBED;
-			ObservationRegistry observationRegistry = ObservationRegistry.create();
 			ModelManagementOptions modelManagementOptions = ModelManagementOptions.defaults();
 			OllamaEmbeddingModel model = new OllamaEmbeddingModel(ollamaapi, options, observationRegistry,
 					modelManagementOptions);

--- a/gebo.llms.parent/gebo.llms.onxx-embeddings/src/main/java/ai/gebo/llms/onxx_transformers_embedding/services/ONNXTransformersEmbeddingModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.onxx-embeddings/src/main/java/ai/gebo/llms/onxx_transformers_embedding/services/ONNXTransformersEmbeddingModelConfigurationSupportService.java
@@ -30,6 +30,7 @@ import ai.gebo.llms.onxx_transformers_embedding.model.GONNXTransformersEmbedding
 import ai.gebo.llms.onxx_transformers_embedding.model.GONNXTransformersEmbeddingModelConfig;
 import ai.gebo.model.OperationStatus;
 import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import io.micrometer.observation.ObservationRegistry;
 import jakarta.el.MethodNotFoundException;
 import lombok.AllArgsConstructor;
 
@@ -67,6 +68,7 @@ public class ONNXTransformersEmbeddingModelConfigurationSupportService implement
 	 */
 	final IGeboSecretsAccessService secretService;
 	final ModelRuntimeConfigureHandler configureHandler;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Inner class that implements the configurable embedding model for ONNX
@@ -79,7 +81,8 @@ public class ONNXTransformersEmbeddingModelConfigurationSupportService implement
 		 * Constructor that initializes the model with a vector store factory provider
 		 */
 		public OllamaConfigurableEmbeddingModel() {
-			super(storeFactoryProvider);
+			super(storeFactoryProvider,
+					ONNXTransformersEmbeddingModelConfigurationSupportService.this.observationRegistry);
 		}
 
 		/**

--- a/gebo.llms.parent/gebo.llms.openai/src/main/java/ai/gebo/llms/openai/services/OpenAIChatModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.openai/src/main/java/ai/gebo/llms/openai/services/OpenAIChatModelConfigurationSupportService.java
@@ -76,6 +76,7 @@ public class OpenAIChatModelConfigurationSupportService
 	final ModelRuntimeConfigureHandler configureHandler;
 	final IGDocumentContentRendererProvider documentContentRenderProvider;
 	final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Implementation of a configurable chat model for OpenAI. This class handles
@@ -85,8 +86,8 @@ public class OpenAIChatModelConfigurationSupportService
 
 		public OpenAIConfigurableChatModel(IGDocumentContentRendererProvider rendererFactory,
 				IGToolCallbackSourceRepositoryPattern toolCallbacksRepository,
-				IChatModelUsageAdvisorFactory usageAdvisorFactory) {
-			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+				IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
+			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 
 		}
 
@@ -165,7 +166,7 @@ public class OpenAIChatModelConfigurationSupportService
 			OpenAiChatModel model = OpenAiChatModel.builder()
 					.options(options)
 					.toolCallingManager(toolCallingManager)
-					.observationRegistry(ObservationRegistry.NOOP)
+					.observationRegistry(observationRegistry)
 					.httpClientBuilderCustomizer(OpenAiClientCustomizer.from(serviceClientsProviderFactory.get(getCode())))
 					.build();
 
@@ -196,7 +197,8 @@ public class OpenAIChatModelConfigurationSupportService
 		@Override
 		protected IGConfigurableChatModel cloneMeWithInjection() {
 
-			return new OpenAIConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+			return new OpenAIConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory,
+					observationRegistry);
 		}
 	};
 
@@ -221,7 +223,7 @@ public class OpenAIChatModelConfigurationSupportService
 	public IGConfigurableChatModel<GOpenAIChatModelConfig> create(GOpenAIChatModelConfig config)
 			throws LLMConfigException {
 		OpenAIConfigurableChatModel model = new OpenAIConfigurableChatModel(documentContentRenderProvider,
-				functionsRepo, usageAdvisorFactory);
+				functionsRepo, usageAdvisorFactory, observationRegistry);
 		model.initialize(config, type);
 		return model;
 	}

--- a/gebo.llms.parent/gebo.llms.openai/src/main/java/ai/gebo/llms/openai/services/OpenAIEmbeddingModelConfigurationSupportService.java
+++ b/gebo.llms.parent/gebo.llms.openai/src/main/java/ai/gebo/llms/openai/services/OpenAIEmbeddingModelConfigurationSupportService.java
@@ -43,6 +43,7 @@ import ai.gebo.secrets.model.GeboTokenContent;
 import ai.gebo.architecture.persistence.GeboPersistenceException;
 import ai.gebo.crypting.services.GeboCryptSecretException;
 import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.AllArgsConstructor;
 
 /**
@@ -101,6 +102,7 @@ public class OpenAIEmbeddingModelConfigurationSupportService implements
 	 */
 	final IGLlmsServiceClientsProviderFactory serviceClientsProviderFactory;
 	final ModelRuntimeConfigureHandler configureHandler;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Inner class that implements the configurable embedding model for OpenAI
@@ -112,7 +114,7 @@ public class OpenAIEmbeddingModelConfigurationSupportService implements
 		 * Constructor for OpenAI configurable embedding model
 		 */
 		public OpenAIConfigurableEmbeddingModel() {
-			super(storeFactoryProvider);
+			super(storeFactoryProvider, OpenAIEmbeddingModelConfigurationSupportService.this.observationRegistry);
 		}
 
 		/**
@@ -155,6 +157,7 @@ public class OpenAIEmbeddingModelConfigurationSupportService implements
 			OpenAiEmbeddingModel model = OpenAiEmbeddingModel.builder()
 					.options(options)
 					.metadataMode(MetadataMode.EMBED)
+					.observationRegistry(observationRegistry)
 					.httpClientBuilderCustomizer(OpenAiClientCustomizer.from(serviceClientsProviderFactory.get(getCode())))
 					.build();
 			return model;

--- a/gebo.llms.parent/gebo.llms.tests.services/src/main/java/ai/gebo/llms/abstraction/layer/tests/TestChatModelSupportServiceImpl.java
+++ b/gebo.llms.parent/gebo.llms.tests.services/src/main/java/ai/gebo/llms/abstraction/layer/tests/TestChatModelSupportServiceImpl.java
@@ -26,6 +26,7 @@ import ai.gebo.llms.abstraction.layer.services.IGChatModelConfigurationSupportSe
 import ai.gebo.llms.abstraction.layer.services.IGConfigurableChatModel;
 import ai.gebo.llms.abstraction.layer.services.LLMConfigException;
 import ai.gebo.model.OperationStatus;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.AllArgsConstructor;
 
 /**
@@ -51,6 +52,7 @@ public class TestChatModelSupportServiceImpl extends AbstractTestingBusinessLogi
 	final IGDocumentContentRendererProvider documentContentRenderProvider;
 	final IGToolCallbackSourceRepositoryPattern toolCallbacksRepository;
 	final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Inner class representing a test implementation of the configurable chat
@@ -61,8 +63,8 @@ public class TestChatModelSupportServiceImpl extends AbstractTestingBusinessLogi
 
 		public TestConfigurableChatModel(IGDocumentContentRendererProvider rendererFactory,
 				IGToolCallbackSourceRepositoryPattern toolCallbacksRepository,
-				IChatModelUsageAdvisorFactory usageAdvisorFactory) {
-			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+				IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
+			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 
 		}
 
@@ -85,7 +87,8 @@ public class TestChatModelSupportServiceImpl extends AbstractTestingBusinessLogi
 		@Override
 		protected IGConfigurableChatModel cloneMeWithInjection() {
 
-			return new TestConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+			return new TestConfigurableChatModel(rendererFactory, toolCallbacksRepository, usageAdvisorFactory,
+					observationRegistry);
 		}
 
 	};
@@ -148,7 +151,7 @@ public class TestChatModelSupportServiceImpl extends AbstractTestingBusinessLogi
 	public IGConfigurableChatModel<TestChatModelConfiguration> create(TestChatModelConfiguration config)
 			throws LLMConfigException {
 		TestConfigurableChatModel out = new TestConfigurableChatModel(documentContentRenderProvider,
-				toolCallbacksRepository, usageAdvisorFactory);
+				toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 		out.initialize(config, type);
 		return out;
 	}

--- a/gebo.llms.parent/gebo.llms.tests.services/src/main/java/ai/gebo/llms/abstraction/layer/tests/TestEmbeddingModelSupportServiceImpl.java
+++ b/gebo.llms.parent/gebo.llms.tests.services/src/main/java/ai/gebo/llms/abstraction/layer/tests/TestEmbeddingModelSupportServiceImpl.java
@@ -27,6 +27,7 @@ import ai.gebo.llms.abstraction.layer.services.IGEmbeddingModelConfigurationSupp
 import ai.gebo.llms.abstraction.layer.services.LLMConfigException;
 import ai.gebo.llms.abstraction.layer.vectorstores.IGVectorStoreFactoryProvider;
 import ai.gebo.model.OperationStatus;
+import io.micrometer.observation.ObservationRegistry;
 
 /**
  * AI generated comments
@@ -47,7 +48,9 @@ public class TestEmbeddingModelSupportServiceImpl extends AbstractTestingBusines
 	/** Provider for vector store factories */
 	@Autowired
 	IGVectorStoreFactoryProvider factoryProvider;
-	
+	@Autowired
+	ObservationRegistry observationRegistry;
+
 	/**
 	 * Static initializer to set up the test model types and codes
 	 */
@@ -69,8 +72,9 @@ public class TestEmbeddingModelSupportServiceImpl extends AbstractTestingBusines
 		 * 
 		 * @param storeFactoryProvider The provider for vector store factories
 		 */
-		public TestConfigurableEmbeddingModel(IGVectorStoreFactoryProvider storeFactoryProvider) {
-			super(storeFactoryProvider);
+		public TestConfigurableEmbeddingModel(IGVectorStoreFactoryProvider storeFactoryProvider,
+				ObservationRegistry observationRegistry) {
+			super(storeFactoryProvider, observationRegistry);
 
 		}
 
@@ -142,7 +146,7 @@ public class TestEmbeddingModelSupportServiceImpl extends AbstractTestingBusines
 	@Override
 	public IGConfigurableEmbeddingModel<TestEmbeddingModelConfiguration> create(TestEmbeddingModelConfiguration config)
 			throws LLMConfigException {
-		TestConfigurableEmbeddingModel em = new TestConfigurableEmbeddingModel(factoryProvider);
+		TestConfigurableEmbeddingModel em = new TestConfigurableEmbeddingModel(factoryProvider, observationRegistry);
 		em.initialize(config, type);
 		return em;
 	}

--- a/gebo.llms.parent/gebo.llms.tests.services/src/main/java/ai/gebo/llms/abstraction/layer/tests/TestKnowledgeExtractionChatModelSupportServiceImpl.java
+++ b/gebo.llms.parent/gebo.llms.tests.services/src/main/java/ai/gebo/llms/abstraction/layer/tests/TestKnowledgeExtractionChatModelSupportServiceImpl.java
@@ -27,6 +27,7 @@ import ai.gebo.llms.abstraction.layer.services.IGChatModelConfigurationSupportSe
 import ai.gebo.llms.abstraction.layer.services.IGConfigurableChatModel;
 import ai.gebo.llms.abstraction.layer.services.LLMConfigException;
 import ai.gebo.model.OperationStatus;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.AllArgsConstructor;
 
 /**
@@ -52,6 +53,7 @@ public class TestKnowledgeExtractionChatModelSupportServiceImpl extends Abstract
 	final IGDocumentContentRendererProvider documentsRenderProvider;
 	final IGToolCallbackSourceRepositoryPattern toolCallbacksRepository;
 	final IChatModelUsageAdvisorFactory usageAdvisorFactory;
+	final ObservationRegistry observationRegistry;
 
 	/**
 	 * Inner class representing a test implementation of the configurable chat
@@ -62,8 +64,8 @@ public class TestKnowledgeExtractionChatModelSupportServiceImpl extends Abstract
 
 		public TestConfigurableKnowledgeExtractionChatModel(IGDocumentContentRendererProvider rendererFactory,
 				IGToolCallbackSourceRepositoryPattern toolCallbacksRepository,
-				IChatModelUsageAdvisorFactory usageAdvisorFactory) {
-			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory);
+				IChatModelUsageAdvisorFactory usageAdvisorFactory, ObservationRegistry observationRegistry) {
+			super(rendererFactory, toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 
 		}
 
@@ -101,7 +103,7 @@ public class TestKnowledgeExtractionChatModelSupportServiceImpl extends Abstract
 		protected IGConfigurableChatModel cloneMeWithInjection() {
 
 			return new TestConfigurableKnowledgeExtractionChatModel(rendererFactory, toolCallbacksRepository,
-					usageAdvisorFactory);
+					usageAdvisorFactory, observationRegistry);
 		}
 
 	};
@@ -165,7 +167,7 @@ public class TestKnowledgeExtractionChatModelSupportServiceImpl extends Abstract
 	public IGConfigurableChatModel<TestKnowledgeExtractionModelConfiguration> create(
 			TestKnowledgeExtractionModelConfiguration config) throws LLMConfigException {
 		TestConfigurableKnowledgeExtractionChatModel out = new TestConfigurableKnowledgeExtractionChatModel(
-				documentsRenderProvider, toolCallbacksRepository, usageAdvisorFactory);
+				documentsRenderProvider, toolCallbacksRepository, usageAdvisorFactory, observationRegistry);
 		out.initialize(config, type);
 		return out;
 	}

--- a/gebo.microservices.architecture.parent/gebo.microservices.starter/pom.xml
+++ b/gebo.microservices.architecture.parent/gebo.microservices.starter/pom.xml
@@ -24,6 +24,11 @@
 			<artifactId>gebo.microservices.topology</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>ai.gebo.architecture</groupId>
+			<artifactId>gebo.architecture.telemetry</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/gebo.ragsystem.parent/gebo.ragsystem.content.vectorizator/src/main/java/ai/gebo/ragsystem/content/vectorizator/impl/GEmbedderImpl.java
+++ b/gebo.ragsystem.parent/gebo.ragsystem.content.vectorizator/src/main/java/ai/gebo/ragsystem/content/vectorizator/impl/GEmbedderImpl.java
@@ -31,6 +31,7 @@ import org.springframework.ai.document.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
 import ai.gebo.application.messaging.SystemComponentType;
 import ai.gebo.application.messaging.model.GMessageEnvelope;
 import ai.gebo.application.messaging.model.GStandardModulesConstraints;
@@ -58,6 +59,9 @@ public class GEmbedderImpl implements IGEmbedder {
 
 	@Autowired
 	VectorizedContentRepository vectorizedContentRepository;
+
+	@Autowired
+	IMessageEnvelopeFactory envelopeFactory;
 
 	/**
 	 * Default constructor for GTokenizatorAndEmbedderImpl.
@@ -373,7 +377,7 @@ public class GEmbedderImpl implements IGEmbedder {
 		for (GContentsProcessingStatusUpdatePayload vectPayload : vectorizationStatistics.values()) {
 			Map<String, Boolean> map = distinctJobDocumentVectorized.get(vectPayload.getJobId());
 			vectPayload.setBatchDocumentsProcessed((long) (map != null ? map.size() : 0));
-			GMessageEnvelope<GContentsProcessingStatusUpdatePayload> msg = GMessageEnvelope.newMessageFrom(emitter,
+			GMessageEnvelope<GContentsProcessingStatusUpdatePayload> msg = envelopeFactory.newMessageFrom(emitter,
 					vectPayload);
 			msg.setTargetModule(GStandardModulesConstraints.JOBS_MASTER);
 			msg.setTargetComponent(GStandardModulesConstraints.USER_MESSAGES_CONCENTRATOR_COMPONENT);
@@ -406,7 +410,7 @@ public class GEmbedderImpl implements IGEmbedder {
 		for (GUserMessage userMessage : allUserMessages) {
 			GUserMessagePayload payload = new GUserMessagePayload();
 			payload.setUserMessage(userMessage);
-			GMessageEnvelope<GUserMessagePayload> userMessageMsg = GMessageEnvelope.newMessageFrom(emitter, payload);
+			GMessageEnvelope<GUserMessagePayload> userMessageMsg = envelopeFactory.newMessageFrom(emitter, payload);
 			userMessageMsg.setTargetModule(GStandardModulesConstraints.JOBS_MASTER);
 			userMessageMsg.setTargetComponent(GStandardModulesConstraints.USER_MESSAGES_CONCENTRATOR_COMPONENT);
 			userMessageMsg.setTargetType(SystemComponentType.APPLICATION_COMPONENT);
@@ -457,7 +461,7 @@ public class GEmbedderImpl implements IGEmbedder {
 				if (documentAccessResult.getNegativeMessage() != null) {
 					GUserMessagePayload payload = new GUserMessagePayload();
 					payload.setUserMessage(documentAccessResult.getNegativeMessage());
-					GMessageEnvelope<GUserMessagePayload> userMessageMsg = GMessageEnvelope.newMessageFrom(emitter,
+					GMessageEnvelope<GUserMessagePayload> userMessageMsg = envelopeFactory.newMessageFrom(emitter,
 							payload);
 					payload.getUserMessage()
 							.setJobId(documentAccessResult.getDocReferenceMessage().getPayload().getJobId());
@@ -471,7 +475,7 @@ public class GEmbedderImpl implements IGEmbedder {
 
 		// Send vectorization status updates for each job with errors
 		for (GContentsProcessingStatusUpdatePayload vectPayload : payloads.values()) {
-			GMessageEnvelope<GContentsProcessingStatusUpdatePayload> msg = GMessageEnvelope.newMessageFrom(emitter,
+			GMessageEnvelope<GContentsProcessingStatusUpdatePayload> msg = envelopeFactory.newMessageFrom(emitter,
 					vectPayload);
 			msg.setTargetModule(GStandardModulesConstraints.JOBS_MASTER);
 			msg.setTargetComponent(GStandardModulesConstraints.USER_MESSAGES_CONCENTRATOR_COMPONENT);


### PR DESCRIPTION
## Summary
- Adds a shared `gebo.architecture.telemetry` module (actuator, Micrometer, tracing, `ObservedAspect`) wired into both the monolithic and microservices starters plus the gateway, so metrics/tracing are inherited uniformly.
- Fixes 11+ LLM vendor integrations (Anthropic, OpenAI, Bedrock, Mistral, Ollama, DeepSeek, Google Vertex, generic-openai-compatible, ONNX) whose Spring AI models were wired to a disconnected/no-op `ObservationRegistry`, silently discarding built-in chat/embedding observability.
- Adds `@Observed` to the two shared controller-base families (LLM config CRUD, content-system integrations).
- Instruments the message broker end to end: `IMessageEnvelopeFactory`/`IGMessageDeliveryObserver` DI seams (creation and delivery aren't reachable by Spring AOP proxies), a trace-context field on `GMessageEnvelope` that survives the RabbitMQ hop via the existing JSON codec, and an AOP aspect around `IGMessageBroker.accept()`/`broadcast()` for routing spans.
- Adds trace/span log correlation, `spring.application.name`, and management/tracing config on the monolith and microservices.
- Adds Prometheus/Grafana/Tempo/OTel-Collector to both docker-compose stacks, with Grafana datasources and a starter dashboard auto-provisioned on first `docker compose up`.

## Test plan
- [x] Full-repo `mvn clean compile` — BUILD SUCCESS
- [x] `gebo.ai.app` test suite — 17/17 passing, 0 failures/errors
- [ ] Bring up `docker compose` and confirm Grafana shows live metrics/traces
- [ ] Trigger a chat call against at least two LLM vendors and confirm `gen_ai.*` spans/metrics appear