### PR TITLE
Concentrate LLM usage tracking into tyr via internal messaging

### DIFF
--- a/.claude/skills/document-microservices-controllers/scripts/generate_controllers_doc.py
+++ b/.claude/skills/document-microservices-controllers/scripts/generate_controllers_doc.py
@@ -38,7 +38,7 @@ SERVICES = [
     ("heimdall", 13018, "heimdall-gebo-ai"),
     ("tyr", 13019, "tyr-gebo-ai"),
 ]
-NO_CONTROLLER_SERVICES = {"gateway", "eureka"}
+NO_CONTROLLER_SERVICES = {"gateway", "eureka", "fulltextor"}
 NOTES_NO_CONTROLLERS = {
     "gateway": "Gateway routes to backends via `lb://`; it hosts no controllers of its own — "
                "its own `/v3/api-docs` is empty by design (it proxies/aggregates the backends' "
@@ -46,6 +46,15 @@ NOTES_NO_CONTROLLERS = {
     "eureka": "The Eureka **registry** itself; it is not a `swagger-on` service and exposes no "
               "`/v3/api-docs` — this is the registry dashboard/REST API (`/eureka/apps`), not a "
               "Gebo controller.",
+    "fulltextor": "A pure message-driven worker: confirmed by grepping its entire dependency "
+                  "tree for `@RestController` (none exist anywhere in it) and by its clean "
+                  "startup log, which registers `IGMessageReceiver`/`IGMessageEmitter` for "
+                  "`fulltext-module.fulltext-indexing-component` and connects to OpenSearch — "
+                  "it consumes chunk-availability messages, downloads the chunk via the "
+                  "documents-cache client, and writes it to OpenSearch, with no REST admin "
+                  "surface of its own. Its previously-shown 5 controllers were entirely the "
+                  "`contentsystems.abstraction.layer` leak (see the top-of-file note); 0 is "
+                  "the correct steady state, not a failure.",
 }
 
 

--- a/docs/MICROSERVICES-CONTROLLERS.md
+++ b/docs/MICROSERVICES-CONTROLLERS.md
@@ -6,20 +6,9 @@ Generated from each running microservice's live `/v3/api-docs` (springdoc), afte
 
 **LLM controllers-review note:** the concrete, mapped LLM admin controllers (`ChatModelsController`, `EmbeddingModelsControllers`, `ImageModelsController`, `RankerModelsController`, `TextToSpeechModelsController`, `TranscriptModelsController`, `ChatModelsLookupController`, `FunctionsLookupController`) live in a sibling `gebo.architecture.llms.abstraction.layer.controllers` module, wired only into `gebo.apps.monolithic.starter` and `brain.gebo.ai`. Each LLM provider driver (openai, mistral, generic-openai-compatible, ollama, onxx-embeddings, anthropic3, google_vertex, deepseek, aws-bedrock) got the same treatment: its admin controllers moved to a `<provider>.controllers` sibling module, aggregated by `gebo.llms.controllers.starter`, wired the same way (monolith + brain only). **Effect:** vectorizator and graphicator do not expose any of these — brain is the sole microservice hosting LLM configuration admin, and also carries every provider-specific admin controller. `gebo.llms.setup` (fast-setup, `GeboFastLLMSSetupController`) is likewise wired only on monolith + brain, kept separate from `gebo.llms.starter` (which `gebo.microservices.llms.starter` now depends on for the Hazelcast models-replication cache to deserialize provider-specific config classes on every LLM-hosting microservice) so it doesn't leak onto vectorizator/graphicator.
 
-**Workflows consolidated into the new tyr.gebo.ai (port 13019):** `job-status-controller` and `workflow-stats-admin-level-controller` used to be duplicated on every content-ingesting microservice (vectorizator, graphicator, chunker, git, filesystem, uploads, userspace, sharepoint, confluence, jira, aws-s3, googledrive, mcpclient, integration, fulltextor). They've been removed from all of them and now live solely on the new `tyr` microservice, the JOBS_MASTER workflow/usage-tracking home consolidated out of `content.abstraction.layer` into `gebo.architecture.compute.workflows`. `tyr` currently exposes just those 2 controllers (3 endpoints); each other microservice's controller/endpoint count dropped by 2 controllers / 3 endpoints accordingly.
+**LLM usage tracking lives on tyr.gebo.ai (port 13019), not brain:** `LLMSUsageAdminLevelController`/`LLMSUsageUserLevelController`, their backing `LLMSUsageAggregationService`, and the `LLMUsageDetail`/`LLMDailyUsageDetail` entities/repositories/daily-consolidation job all live in package `ai.gebo.architecture.llms.usage` inside `gebo.architecture.compute.workflow` — the same module that hosts `job-status-controller`/`workflow-stats-admin-level-controller`. `LLMSUsageCrudServiceImpl` (in `gebo.architecture.llms.abstraction.layer`, on every LLM-hosting microservice's classpath) never writes Mongo itself: it emits a `LLMUsageDetailPayload` message addressed to `LLMS-USAGE-MONITOR`/`USAGE-CONCENTRATOR`, which a dedicated threaded receiver in `compute.workflow` picks up and persists — the same `JOBS_MASTER`/`END_OF_WORKFLOW_COMPUTE_SERVICE` pattern already used for workflow completion.
 
-Bringing `tyr` up initially crash-looped with `UnsatisfiedDependencyException: ... field
-'jobsRepo' ... No qualifying bean of type 'JobStatusRepository'`. Cause: `TyrApplication`
-had `@ComponentScan(basePackages = "ai.gebo")` but was missing
-`@EnableMongoRepositories(basePackages = "ai.gebo")` — Spring Data's Mongo repository
-scan defaults to the main class's own package, not the `@ComponentScan` bases, so it
-never found `ai.gebo.knowledgebase.repositories.JobStatusRepository` even though it was
-on the classpath. Every other data-backed microservice (`brain`, `uploads`,
-`vectorizator`, ...) already carries this annotation; `TyrApplication` was just missing
-it as a new module. Fixed by adding the annotation to match the existing pattern.
-
-The doc-generation skill's port map, polling list, and the generator script's `SERVICES`
-table were also updated to include `tyr` (previously only 13000–13018 were tracked).
+`gebo.architecture.compute.workflow` is deliberately wired on exactly two apps: `tyr.gebo.ai` (direct dependency) and the monolith (`gebo.apps.monolithic.starter`, transitive into `gebo.ai.app`) — nowhere else, so its controllers, receivers, and scheduled jobs run in exactly one place per deployment shape rather than being duplicated onto every microservice that happens to depend on it. `tyr` additionally carries the same remote security/secrets/ACL client trio every non-heimdall microservice gets (`gebo.microservices.secrets.client`, `gebo.microservices.security.client`, `gebo.microservices.acl.client`) — needed because `LLMSUsageUserLevelController` depends on `IGSecurityService`, which pulls in `gebo.architecture.security`'s full security config and its `IGeboSecretsAccessService` dependency; `tyr`'s own `gebo.microservices.starter` base deliberately excludes these clients since `heimdall` (the actual security microservice) is built on that same starter and must not carry both a local and a remote implementation of the same interface.
 
 
 ## Summary
@@ -27,7 +16,7 @@ table were also updated to include `tyr` (previously only 13000–13018 were tra
 | Service | Port | Context-path | Controllers | Endpoints |
 |---|---|---|---|---|
 | gateway.gebo.ai | 13000 | `—` | 0 | 0 |
-| brain.gebo.ai | 13001 | `/brain` | 57 | 226 |
+| brain.gebo.ai | 13001 | `/brain` | 53 | 221 |
 | vectorizator.gebo.ai | 13002 | `/vectorizator` | 7 | 14 |
 | graphicator.gebo.ai | 13003 | `/graphicator` | 6 | 12 |
 | chunker.gebo.ai | 13004 | `/chunker` | 4 | 16 |
@@ -45,7 +34,7 @@ table were also updated to include `tyr` (previously only 13000–13018 were tra
 | fulltextor.gebo.ai | 13016 | `/fulltextor` | 5 | 10 |
 | eureka.gebo.ai | 13017 | `—` | 0 | 0 |
 | heimdall.gebo.ai | 13018 | `/heimdall` | 14 | 55 |
-| tyr.gebo.ai | 13019 | `/tyr` | 2 | 3 |
+| tyr.gebo.ai | 13019 | `/tyr` | 4 | 5 |
 
 
 ## gateway.gebo.ai — port 13000 (`gateway-gebo-ai`)
@@ -55,7 +44,7 @@ _Gateway routes to backends via `lb://`; it hosts no controllers of its own — 
 
 ## brain.gebo.ai — port 13001 (`brain-gebo-ai`) — context-path `/brain`
 
-57 controller(s), 226 endpoint(s):
+53 controller(s), 221 endpoint(s):
 
 
 ### `anthropic-chat-models-configuration-controller`
@@ -394,22 +383,6 @@ _Gateway routes to backends via `lb://`; it hosts no controllers of its own — 
 | POST | `/brain/api/admin/JobLauncherController/createJob` | createJob |
 | POST | `/brain/api/admin/JobLauncherController/getHasRunningJobs` | getHasRunningJobs |
 
-### `job-status-controller`
-| Method | Path | Operation |
-|---|---|---|
-| GET | `/brain/api/admin/JobStatusController/getJobStatus` | getJobStatus |
-| GET | `/brain/api/admin/JobStatusController/getJobSummary` | getJobSummary |
-
-### `llms-usage-admin-level-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/brain/api/admin/LLMSUsageAdminLevelController/drillDown` | adminDrillDown |
-
-### `llms-usage-user-level-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/brain/api/users/LLMSUsageUserLevelController/drillDown` | userDrillDown |
-
 ### `ollama-chat-models-configuration-controller`
 | Method | Path | Operation |
 |---|---|---|
@@ -506,11 +479,6 @@ _Gateway routes to backends via `lb://`; it hosts no controllers of its own — 
 |---|---|---|
 | GET | `/brain/api/admin/TranscriptModelsController/getRuntimeConfiguredTranscriptModels` | getRuntimeConfiguredTranscriptModels |
 | GET | `/brain/api/admin/TranscriptModelsController/getTranscriptModelTypes` | getTranscriptModelTypes |
-
-### `workflow-stats-admin-level-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/brain/api/admin/WorkflowStatsAdminLevelController/drillDown` | workflowDrillDown |
 
 ## vectorizator.gebo.ai — port 13002 (`vectorizator-gebo-ai`) — context-path `/vectorizator`
 
@@ -1454,7 +1422,7 @@ _The Eureka **registry** itself; it is not a `swagger-on` service and exposes no
 
 ## tyr.gebo.ai — port 13019 (`tyr-gebo-ai`) — context-path `/tyr`
 
-2 controller(s), 3 endpoint(s):
+4 controller(s), 5 endpoint(s):
 
 
 ### `job-status-controller`
@@ -1462,6 +1430,16 @@ _The Eureka **registry** itself; it is not a `swagger-on` service and exposes no
 |---|---|---|
 | GET | `/tyr/api/admin/JobStatusController/getJobStatus` | getJobStatus |
 | GET | `/tyr/api/admin/JobStatusController/getJobSummary` | getJobSummary |
+
+### `llms-usage-admin-level-controller`
+| Method | Path | Operation |
+|---|---|---|
+| POST | `/tyr/api/admin/LLMSUsageAdminLevelController/drillDown` | adminDrillDown |
+
+### `llms-usage-user-level-controller`
+| Method | Path | Operation |
+|---|---|---|
+| POST | `/tyr/api/users/LLMSUsageUserLevelController/drillDown` | userDrillDown |
 
 ### `workflow-stats-admin-level-controller`
 | Method | Path | Operation |

--- a/docs/MICROSERVICES-CONTROLLERS.md
+++ b/docs/MICROSERVICES-CONTROLLERS.md
@@ -6,9 +6,12 @@ Generated from each running microservice's live `/v3/api-docs` (springdoc), afte
 
 **LLM controllers-review note:** the concrete, mapped LLM admin controllers (`ChatModelsController`, `EmbeddingModelsControllers`, `ImageModelsController`, `RankerModelsController`, `TextToSpeechModelsController`, `TranscriptModelsController`, `ChatModelsLookupController`, `FunctionsLookupController`) live in a sibling `gebo.architecture.llms.abstraction.layer.controllers` module, wired only into `gebo.apps.monolithic.starter` and `brain.gebo.ai`. Each LLM provider driver (openai, mistral, generic-openai-compatible, ollama, onxx-embeddings, anthropic3, google_vertex, deepseek, aws-bedrock) got the same treatment: its admin controllers moved to a `<provider>.controllers` sibling module, aggregated by `gebo.llms.controllers.starter`, wired the same way (monolith + brain only). **Effect:** vectorizator and graphicator do not expose any of these — brain is the sole microservice hosting LLM configuration admin, and also carries every provider-specific admin controller. `gebo.llms.setup` (fast-setup, `GeboFastLLMSSetupController`) is likewise wired only on monolith + brain, kept separate from `gebo.llms.starter` (which `gebo.microservices.llms.starter` now depends on for the Hazelcast models-replication cache to deserialize provider-specific config classes on every LLM-hosting microservice) so it doesn't leak onto vectorizator/graphicator.
 
-**LLM usage tracking lives on tyr.gebo.ai (port 13019), not brain:** `LLMSUsageAdminLevelController`/`LLMSUsageUserLevelController`, their backing `LLMSUsageAggregationService`, and the `LLMUsageDetail`/`LLMDailyUsageDetail` entities/repositories/daily-consolidation job all live in package `ai.gebo.architecture.llms.usage` inside `gebo.architecture.compute.workflow` — the same module that hosts `job-status-controller`/`workflow-stats-admin-level-controller`. `LLMSUsageCrudServiceImpl` (in `gebo.architecture.llms.abstraction.layer`, on every LLM-hosting microservice's classpath) never writes Mongo itself: it emits a `LLMUsageDetailPayload` message addressed to `LLMS-USAGE-MONITOR`/`USAGE-CONCENTRATOR`, which a dedicated threaded receiver in `compute.workflow` picks up and persists — the same `JOBS_MASTER`/`END_OF_WORKFLOW_COMPUTE_SERVICE` pattern already used for workflow completion.
+**`gebo.architecture.contentsystems.abstraction.layer` is scoped to the services that actually own content-system endpoints:** `job-launcher-controller`, `contents-reset-controller`, `generical-publisher-controller`, and `document-content-streamer-controller` (all four bundled in that one module, package `ai.gebo.systems.abstraction.layer.controllers`/`ai.gebo.jobs.services.controllers`) are legitimate on the 11 real content-handler microservices (git, filesystem, uploads, userspace, sharepoint, confluence, jira, aws-s3, googledrive, mcpclient, integration) — each hosts its own systems controller extending `GAbstractSystemsArchitectureController`, and `document-content-streamer-controller` specifically is how each serves its own locally-owned content back to chunker's cache-backed proxy. They are **not** legitimate on brain, vectorizator, graphicator, or fulltextor, none of which own a content-system endpoint:
+- `AIDocumentsCacheService` (`gebo.architecture.rag.support.layer`, reached by brain and graphicator via `gebo.architecture.chat.abstraction.layer`) now resolves document content through `IGDocumentContentStreamer` — the same deployment-aware abstraction `document-content-streamer-controller` itself uses (local on the monolith, chunker-proxying on microservices) — instead of a direct, locally-scoped `IGContentManagementSystemHandlerRepositoryPattern.findByHandledEndpoint(...)` lookup that only ever resolved on the monolith, where every content handler happens to be co-located. On brain and graphicator that lookup always returned `null` — no content-handler beans exist on either service — so the RAG full-document-contents path was a silent no-op there. `rag.support.layer`'s pom no longer depends on `gebo.architecture.contentsystems.abstraction.layer`.
+- `gebo.ragsystem.content.vectorizator` and `gebo.ragsystem.content.fulltext.processor` (vectorizator's and fulltextor's own business-logic modules) carried a direct dependency on `gebo.architecture.contentsystems.abstraction.layer` with zero actual source references to it — both consume purely through generic `gebo.core.messages` payloads (`GDocumentReferencePayload` et al.), sourced from the chunker/documents-cache pipeline, never from a content-handler directly. Dependency removed.
+`fulltextor.gebo.ai` now correctly shows 0 controllers: it never had a REST controller of its own anywhere in its dependency tree — it is a pure message-driven worker consuming chunk-availability messages, downloading each chunk via the documents-cache client, and writing it to OpenSearch. Its previously-shown 5 controllers were entirely the leaked bundle above.
 
-`gebo.architecture.compute.workflow` is deliberately wired on exactly two apps: `tyr.gebo.ai` (direct dependency) and the monolith (`gebo.apps.monolithic.starter`, transitive into `gebo.ai.app`) — nowhere else, so its controllers, receivers, and scheduled jobs run in exactly one place per deployment shape rather than being duplicated onto every microservice that happens to depend on it. `tyr` additionally carries the same remote security/secrets/ACL client trio every non-heimdall microservice gets (`gebo.microservices.secrets.client`, `gebo.microservices.security.client`, `gebo.microservices.acl.client`) — needed because `LLMSUsageUserLevelController` depends on `IGSecurityService`, which pulls in `gebo.architecture.security`'s full security config and its `IGeboSecretsAccessService` dependency; `tyr`'s own `gebo.microservices.starter` base deliberately excludes these clients since `heimdall` (the actual security microservice) is built on that same starter and must not carry both a local and a remote implementation of the same interface.
+**LLM usage tracking lives on tyr.gebo.ai (port 13019), not brain:** `LLMSUsageAdminLevelController`/`LLMSUsageUserLevelController`, their backing `LLMSUsageAggregationService`, and the `LLMUsageDetail`/`LLMDailyUsageDetail` entities/repositories/daily-consolidation job all live in package `ai.gebo.architecture.llms.usage` inside `gebo.architecture.compute.workflow` — the same module that hosts `job-status-controller`/`workflow-stats-admin-level-controller`. `LLMSUsageCrudServiceImpl` (in `gebo.architecture.llms.abstraction.layer`, on every LLM-hosting microservice's classpath) never writes Mongo itself: it emits a `LLMUsageDetailPayload` message addressed to `LLMS-USAGE-MONITOR`/`USAGE-CONCENTRATOR`, which a dedicated threaded receiver in `compute.workflow` picks up and persists — the same `JOBS_MASTER`/`END_OF_WORKFLOW_COMPUTE_SERVICE` pattern already used for workflow completion. `gebo.architecture.compute.workflow` is wired on exactly two apps: `tyr.gebo.ai` (direct dependency) and the monolith (`gebo.apps.monolithic.starter`, transitive into `gebo.ai.app`) — `brain.gebo.ai`'s own pom carried a further direct dependency on it (a leftover from before this consolidation, exposing `job-status-controller` etc. there too, unrelated to LLM usage specifically), which has been removed.
 
 
 ## Summary
@@ -16,9 +19,9 @@ Generated from each running microservice's live `/v3/api-docs` (springdoc), afte
 | Service | Port | Context-path | Controllers | Endpoints |
 |---|---|---|---|---|
 | gateway.gebo.ai | 13000 | `—` | 0 | 0 |
-| brain.gebo.ai | 13001 | `/brain` | 53 | 221 |
-| vectorizator.gebo.ai | 13002 | `/vectorizator` | 7 | 14 |
-| graphicator.gebo.ai | 13003 | `/graphicator` | 6 | 12 |
+| brain.gebo.ai | 13001 | `/brain` | 49 | 214 |
+| vectorizator.gebo.ai | 13002 | `/vectorizator` | 2 | 4 |
+| graphicator.gebo.ai | 13003 | `/graphicator` | 2 | 5 |
 | chunker.gebo.ai | 13004 | `/chunker` | 4 | 16 |
 | git.gebo.ai | 13005 | `/git` | 6 | 22 |
 | filesystem.gebo.ai | 13006 | `/filesystem` | 8 | 30 |
@@ -31,7 +34,7 @@ Generated from each running microservice's live `/v3/api-docs` (springdoc), afte
 | googledrive.gebo.ai | 13013 | `/googledrive` | 8 | 29 |
 | mcpclient.gebo.ai | 13014 | `/mcpclient` | 8 | 28 |
 | integration.gebo.ai | 13015 | `/integration` | 7 | 19 |
-| fulltextor.gebo.ai | 13016 | `/fulltextor` | 5 | 10 |
+| fulltextor.gebo.ai | 13016 | `—` | 0 | 0 |
 | eureka.gebo.ai | 13017 | `—` | 0 | 0 |
 | heimdall.gebo.ai | 13018 | `/heimdall` | 14 | 55 |
 | tyr.gebo.ai | 13019 | `/tyr` | 4 | 5 |
@@ -44,7 +47,7 @@ _Gateway routes to backends via `lb://`; it hosts no controllers of its own — 
 
 ## brain.gebo.ai — port 13001 (`brain-gebo-ai`) — context-path `/brain`
 
-53 controller(s), 221 endpoint(s):
+49 controller(s), 214 endpoint(s):
 
 
 ### `anthropic-chat-models-configuration-controller`
@@ -68,17 +71,6 @@ _Gateway routes to backends via `lb://`; it hosts no controllers of its own — 
 | GET | `/brain/api/users/ChatModelsLookupController/getChatModelTypesLookup` | getChatModelTypesLookup |
 | GET | `/brain/api/users/ChatModelsLookupController/getDefaultChatModel` | getDefaultChatModel |
 | GET | `/brain/api/users/ChatModelsLookupController/getRuntimeConfiguredChatModelsLookup` | getRuntimeConfiguredChatModelsLookup |
-
-### `contents-reset-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/brain/api/admin/ContentsResetController/resetContentsIngestion` | resetContentsIngestion |
-
-### `document-content-streamer-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/brain/api/users/DocumentContentStreamerController/streamDocumentReference` | streamDocumentReference |
-| POST | `/brain/api/users/DocumentContentStreamerController/streamSearchResult` | streamSearchResult |
 
 ### `embedding-models-controllers`
 | Method | Path | Operation |
@@ -358,11 +350,6 @@ _Gateway routes to backends via `lb://`; it hosts no controllers of its own — 
 | POST | `/brain/api/admin/GenericOpenAIAPITranscriptModelsConfigurationController/insertGenericOpenAIAPITranscriptModelConfig` | insertGenericOpenAIAPITranscriptModelConfig |
 | POST | `/brain/api/admin/GenericOpenAIAPITranscriptModelsConfigurationController/updateGenericOpenAIAPITranscriptModelConfig` | updateGenericOpenAIAPITranscriptModelConfig |
 
-### `generical-publisher-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/brain/api/admin/GenericalPublisherController/publishCentralizedEndpoint` | publishCentralizedEndpoint |
-
 ### `image-models-controller`
 | Method | Path | Operation |
 |---|---|---|
@@ -375,13 +362,6 @@ _Gateway routes to backends via `lb://`; it hosts no controllers of its own — 
 | GET | `/brain/api/users/IngestionFileTypesLibraryController/getAllFileTypes` | getAllFileTypes |
 | GET | `/brain/api/users/IngestionFileTypesLibraryController/getIngestionFileTypeByExtension` | getIngestionFileTypeByExtension |
 | GET | `/brain/api/users/IngestionFileTypesLibraryController/getIngestionReadingModules` | getIngestionReadingModules |
-
-### `job-launcher-controller`
-| Method | Path | Operation |
-|---|---|---|
-| GET | `/brain/api/admin/JobLauncherController/abortJob` | abortJob |
-| POST | `/brain/api/admin/JobLauncherController/createJob` | createJob |
-| POST | `/brain/api/admin/JobLauncherController/getHasRunningJobs` | getHasRunningJobs |
 
 ### `ollama-chat-models-configuration-controller`
 | Method | Path | Operation |
@@ -482,19 +462,8 @@ _Gateway routes to backends via `lb://`; it hosts no controllers of its own — 
 
 ## vectorizator.gebo.ai — port 13002 (`vectorizator-gebo-ai`) — context-path `/vectorizator`
 
-7 controller(s), 14 endpoint(s):
+2 controller(s), 4 endpoint(s):
 
-
-### `contents-reset-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/vectorizator/api/admin/ContentsResetController/resetContentsIngestion` | resetContentsIngestion |
-
-### `document-content-streamer-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/vectorizator/api/users/DocumentContentStreamerController/streamDocumentReference` | streamDocumentReference |
-| POST | `/vectorizator/api/users/DocumentContentStreamerController/streamSearchResult` | streamSearchResult |
 
 ### `gebo-core-analisys-controller`
 | Method | Path | Operation |
@@ -508,40 +477,10 @@ _Gateway routes to backends via `lb://`; it hosts no controllers of its own — 
 | GET | `/vectorizator/api/admin/GeboVectorStoreConfigurationController/getActualVectorStoreConfiguration` | getActualVectorStoreConfiguration |
 | POST | `/vectorizator/api/admin/GeboVectorStoreConfigurationController/vectorStoreConfigurationApplyAndSave` | vectorStoreConfigurationApplyAndSave |
 
-### `generical-publisher-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/vectorizator/api/admin/GenericalPublisherController/publishCentralizedEndpoint` | publishCentralizedEndpoint |
-
-### `ingestion-file-types-library-controller`
-| Method | Path | Operation |
-|---|---|---|
-| GET | `/vectorizator/api/users/IngestionFileTypesLibraryController/getAllFileTypes` | getAllFileTypes |
-| GET | `/vectorizator/api/users/IngestionFileTypesLibraryController/getIngestionFileTypeByExtension` | getIngestionFileTypeByExtension |
-| GET | `/vectorizator/api/users/IngestionFileTypesLibraryController/getIngestionReadingModules` | getIngestionReadingModules |
-
-### `job-launcher-controller`
-| Method | Path | Operation |
-|---|---|---|
-| GET | `/vectorizator/api/admin/JobLauncherController/abortJob` | abortJob |
-| POST | `/vectorizator/api/admin/JobLauncherController/createJob` | createJob |
-| POST | `/vectorizator/api/admin/JobLauncherController/getHasRunningJobs` | getHasRunningJobs |
-
 ## graphicator.gebo.ai — port 13003 (`graphicator-gebo-ai`) — context-path `/graphicator`
 
-6 controller(s), 12 endpoint(s):
+2 controller(s), 5 endpoint(s):
 
-
-### `contents-reset-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/graphicator/api/admin/ContentsResetController/resetContentsIngestion` | resetContentsIngestion |
-
-### `document-content-streamer-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/graphicator/api/users/DocumentContentStreamerController/streamDocumentReference` | streamDocumentReference |
-| POST | `/graphicator/api/users/DocumentContentStreamerController/streamSearchResult` | streamSearchResult |
 
 ### `gebo-vector-store-configuration-controller`
 | Method | Path | Operation |
@@ -549,24 +488,12 @@ _Gateway routes to backends via `lb://`; it hosts no controllers of its own — 
 | GET | `/graphicator/api/admin/GeboVectorStoreConfigurationController/getActualVectorStoreConfiguration` | getActualVectorStoreConfiguration |
 | POST | `/graphicator/api/admin/GeboVectorStoreConfigurationController/vectorStoreConfigurationApplyAndSave` | vectorStoreConfigurationApplyAndSave |
 
-### `generical-publisher-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/graphicator/api/admin/GenericalPublisherController/publishCentralizedEndpoint` | publishCentralizedEndpoint |
-
 ### `ingestion-file-types-library-controller`
 | Method | Path | Operation |
 |---|---|---|
 | GET | `/graphicator/api/users/IngestionFileTypesLibraryController/getAllFileTypes` | getAllFileTypes |
 | GET | `/graphicator/api/users/IngestionFileTypesLibraryController/getIngestionFileTypeByExtension` | getIngestionFileTypeByExtension |
 | GET | `/graphicator/api/users/IngestionFileTypesLibraryController/getIngestionReadingModules` | getIngestionReadingModules |
-
-### `job-launcher-controller`
-| Method | Path | Operation |
-|---|---|---|
-| GET | `/graphicator/api/admin/JobLauncherController/abortJob` | abortJob |
-| POST | `/graphicator/api/admin/JobLauncherController/createJob` | createJob |
-| POST | `/graphicator/api/admin/JobLauncherController/getHasRunningJobs` | getHasRunningJobs |
 
 ## chunker.gebo.ai — port 13004 (`chunker-gebo-ai`) — context-path `/chunker`
 
@@ -1264,40 +1191,10 @@ _Gateway routes to backends via `lb://`; it hosts no controllers of its own — 
 | POST | `/integration/api/admin/JobLauncherController/createJob` | createJob |
 | POST | `/integration/api/admin/JobLauncherController/getHasRunningJobs` | getHasRunningJobs |
 
-## fulltextor.gebo.ai — port 13016 (`fulltextor-gebo-ai`) — context-path `/fulltextor`
+## fulltextor.gebo.ai — port 13016 (`fulltextor-gebo-ai`)
 
-5 controller(s), 10 endpoint(s):
+_No spec captured — service was not reachable when this doc was generated._
 
-
-### `contents-reset-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/fulltextor/api/admin/ContentsResetController/resetContentsIngestion` | resetContentsIngestion |
-
-### `document-content-streamer-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/fulltextor/api/users/DocumentContentStreamerController/streamDocumentReference` | streamDocumentReference |
-| POST | `/fulltextor/api/users/DocumentContentStreamerController/streamSearchResult` | streamSearchResult |
-
-### `generical-publisher-controller`
-| Method | Path | Operation |
-|---|---|---|
-| POST | `/fulltextor/api/admin/GenericalPublisherController/publishCentralizedEndpoint` | publishCentralizedEndpoint |
-
-### `ingestion-file-types-library-controller`
-| Method | Path | Operation |
-|---|---|---|
-| GET | `/fulltextor/api/users/IngestionFileTypesLibraryController/getAllFileTypes` | getAllFileTypes |
-| GET | `/fulltextor/api/users/IngestionFileTypesLibraryController/getIngestionFileTypeByExtension` | getIngestionFileTypeByExtension |
-| GET | `/fulltextor/api/users/IngestionFileTypesLibraryController/getIngestionReadingModules` | getIngestionReadingModules |
-
-### `job-launcher-controller`
-| Method | Path | Operation |
-|---|---|---|
-| GET | `/fulltextor/api/admin/JobLauncherController/abortJob` | abortJob |
-| POST | `/fulltextor/api/admin/JobLauncherController/createJob` | createJob |
-| POST | `/fulltextor/api/admin/JobLauncherController/getHasRunningJobs` | getHasRunningJobs |
 
 ## eureka.gebo.ai — port 13017
 

--- a/gebo.apps.parent/gebo.microservices.apps.parent/brain.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/brain.gebo.ai/pom.xml
@@ -75,11 +75,6 @@
 		</dependency>
 		<dependency>
 			<groupId>ai.gebo.architecture</groupId>
-			<artifactId>gebo.architecture.compute.workflow</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>ai.gebo.architecture</groupId>
 			<artifactId>gebo.architecture.fastsetup.rag</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/tyr.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/tyr.gebo.ai/pom.xml
@@ -29,7 +29,30 @@
 			<artifactId>gebo.architecture.compute.workflow</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+		<!--
+		  The LLMSUsageUserLevelController moved here (from brain, via
+		  gebo.architecture.compute.workflow) pulled in gebo.architecture.security's
+		  full GeboAISecurityConfig, which needs IGeboSecretsAccessService - not
+		  satisfied by the bare gebo.microservices.starter tyr is built on (heimdall
+		  is also built on that starter and must not get these remote-client impls
+		  alongside its own local ones, see gebo.microservices.llms.starter's
+		  comment). Same client trio every other non-heimdall microservice gets.
+		-->
+		<dependency>
+			<groupId>ai.gebo.microservices.architecture</groupId>
+			<artifactId>gebo.microservices.secrets.client</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ai.gebo.microservices.architecture</groupId>
+			<artifactId>gebo.microservices.security.client</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ai.gebo.microservices.architecture</groupId>
+			<artifactId>gebo.microservices.acl.client</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/model/GStandardModulesConstraints.java
+++ b/gebo.architecture.parent/gebo.application.messaging/src/main/java/ai/gebo/application/messaging/model/GStandardModulesConstraints.java
@@ -72,6 +72,14 @@ public class GStandardModulesConstraints {
 	public static final String SYSTEM_SETTINGS_CONTROLLER_COMPONENT = "system-settings-controller-component";
 	public static final String USER_MESSAGES_CONCENTRATOR_COMPONENT = "user-messages-concentrator-component";
 	public static final String END_OF_WORKFLOW_COMPUTE_SERVICE = "end-of-workflow-compute-service";
+	/**
+	 * The LLM usage-tracking concentrator: hosts the receiver in
+	 * {@code gebo.architecture.compute.workflow} (module {@code ai.gebo.architecture.llms.usage})
+	 * that persists {@code LLMUsageDetail} on behalf of every LLM-hosting
+	 * microservice's {@code LLMSUsageCrudServiceImpl} emitter.
+	 */
+	public static final String LLMS_USAGE_MONITOR = "LLMS-USAGE-MONITOR";
+	public static final String USAGE_CONCENTRATOR = "USAGE-CONCENTRATOR";
 	// Lists of modules categorized by their type
 	public static final List<String> EXTERNAl_MODULES = new ArrayList<String>();
 	public static final List<String> UNDER_DEVELOPMENT_MODULES = of();

--- a/gebo.architecture.parent/gebo.architecture.chat.abstraction.layer/src/main/java/ai/gebo/llms/chat/abstraction/layer/services/impl/GChatSessionLifeCycleServiceImpl.java
+++ b/gebo.architecture.parent/gebo.architecture.chat.abstraction.layer/src/main/java/ai/gebo/llms/chat/abstraction/layer/services/impl/GChatSessionLifeCycleServiceImpl.java
@@ -24,6 +24,7 @@ import ai.gebo.architecture.ai.model.GPromptTemplateConfig;
 import ai.gebo.architecture.ai.model.ITokensCountable;
 import ai.gebo.architecture.ai.service.IGPromptConfigDao;
 import ai.gebo.architecture.contenthandling.interfaces.GeboContentHandlerSystemException;
+import ai.gebo.architecture.documents.access.DocumentContentStreamerException;
 import ai.gebo.architecture.persistence.GeboPersistenceException;
 import ai.gebo.architecture.persistence.IGPersistentObjectManager;
 import ai.gebo.architecture.rag.support.layer.model.AIDocumentReferenceItem;
@@ -204,7 +205,7 @@ public class GChatSessionLifeCycleServiceImpl implements IGChatSessionLifeCycleS
 				try {
 					ingested = this.documentsCacheService.retrieve(doc);
 				} catch (GeboPersistenceException | GeboContentHandlerSystemException | IOException
-						| GeboIngestionException e) {
+						| GeboIngestionException | DocumentContentStreamerException e) {
 					throw new GeboChatSessionLifecycleException("Exception in ingesting docs", e);
 				}
 				state = this.fullSessionStateService.addChatWithDocumentToState(state, doc, ingested, index);
@@ -406,7 +407,7 @@ public class GChatSessionLifeCycleServiceImpl implements IGChatSessionLifeCycleS
 		try {
 			data = this.documentsCacheService.retrieve(reference);
 		} catch (GeboPersistenceException | GeboContentHandlerSystemException | IOException
-				| GeboIngestionException e) {
+				| GeboIngestionException | DocumentContentStreamerException e) {
 			throw new GeboChatSessionLifecycleException("Exception in ingesting docs", e);
 		}
 		state = this.fullSessionStateService.addChatWithDocumentToState(state, reference, data, index);

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/pom.xml
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/pom.xml
@@ -42,5 +42,10 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>ai.gebo.architecture</groupId>
+			<artifactId>gebo.architecture.security</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/controller/LLMSUsageAdminLevelController.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/controller/LLMSUsageAdminLevelController.java
@@ -1,4 +1,4 @@
-package ai.gebo.llms.chat.client.rest.controllers;
+package ai.gebo.architecture.llms.usage.controller;
 
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -7,9 +7,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import ai.gebo.llms.chat.client.rest.model.LLMUsageDrillDownLevel;
-import ai.gebo.llms.chat.client.rest.model.LLMUsageDrillDownResult;
-import ai.gebo.llms.chat.client.rest.services.LLMSUsageAggregationService;
+import ai.gebo.architecture.llms.usage.model.LLMUsageDrillDownLevel;
+import ai.gebo.architecture.llms.usage.model.LLMUsageDrillDownResult;
+import ai.gebo.architecture.llms.usage.service.impl.LLMSUsageAggregationService;
 import lombok.AllArgsConstructor;
 
 /**

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/controller/LLMSUsageUserLevelController.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/controller/LLMSUsageUserLevelController.java
@@ -1,4 +1,4 @@
-package ai.gebo.llms.chat.client.rest.controllers;
+package ai.gebo.architecture.llms.usage.controller;
 
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -7,9 +7,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import ai.gebo.llms.chat.client.rest.model.LLMUsageDrillDownLevel;
-import ai.gebo.llms.chat.client.rest.model.LLMUsageDrillDownResult;
-import ai.gebo.llms.chat.client.rest.services.LLMSUsageAggregationService;
+import ai.gebo.architecture.llms.usage.model.LLMUsageDrillDownLevel;
+import ai.gebo.architecture.llms.usage.model.LLMUsageDrillDownResult;
+import ai.gebo.architecture.llms.usage.service.impl.LLMSUsageAggregationService;
 import ai.gebo.security.services.IGSecurityService;
 import lombok.AllArgsConstructor;
 

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMDailyUsageDetail.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMDailyUsageDetail.java
@@ -1,0 +1,32 @@
+package ai.gebo.architecture.llms.usage.model;
+
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import ai.gebo.model.ModelType;
+import lombok.Data;
+
+@Data
+@Document
+public class LLMDailyUsageDetail {
+	@Id
+	private String id = UUID.randomUUID().toString();
+	private String providerId;
+	private String username;
+	private String model;
+	private String callerStack;
+	private ModelType modelType;
+	private int year;
+	private int month;
+	private int day;
+	private long latencyMin;
+	private long latencyMax;
+	private long latencyAvg;
+	private long inputToken;
+	private long outputToken;
+	private long totalToken;
+	private long nrRequests;
+
+}

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMUsageAggregationBucket.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMUsageAggregationBucket.java
@@ -1,6 +1,6 @@
-package ai.gebo.llms.chat.client.rest.model;
+package ai.gebo.architecture.llms.usage.model;
 
-import ai.gebo.llms.abstraction.layer.model.ModelType;
+import ai.gebo.model.ModelType;
 import lombok.Data;
 
 /**

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMUsageDetail.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMUsageDetail.java
@@ -1,32 +1,29 @@
-package ai.gebo.llms.abstraction.layer.model;
+package ai.gebo.architecture.llms.usage.model;
 
 import java.util.UUID;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.HashIndexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import ai.gebo.model.ModelType;
 import lombok.Data;
 
 @Data
 @Document
-public class LLMDailyUsageDetail {
+public class LLMUsageDetail {
 	@Id
 	private String id = UUID.randomUUID().toString();
+
 	private String providerId;
 	private String username;
 	private String model;
 	private String callerStack;
 	private ModelType modelType;
-	private int year;
-	private int month;
-	private int day;
-	private long latencyMin;
-	private long latencyMax;
-	private long latencyAvg;
+	private long latency;
 	private long inputToken;
 	private long outputToken;
 	private long totalToken;
-	private long nrRequests;
-	
-
+	@HashIndexed
+	private long timestamp = System.currentTimeMillis();
 }

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMUsageDrillDownLevel.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMUsageDrillDownLevel.java
@@ -1,6 +1,6 @@
-package ai.gebo.llms.chat.client.rest.model;
+package ai.gebo.architecture.llms.usage.model;
 
-import ai.gebo.llms.abstraction.layer.model.ModelType;
+import ai.gebo.model.ModelType;
 import lombok.Data;
 
 /**

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMUsageDrillDownLevelSubdimensions.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMUsageDrillDownLevelSubdimensions.java
@@ -1,8 +1,8 @@
-package ai.gebo.llms.chat.client.rest.model;
+package ai.gebo.architecture.llms.usage.model;
 
 import java.util.List;
 
-import ai.gebo.llms.abstraction.layer.model.ModelType;
+import ai.gebo.model.ModelType;
 import lombok.Data;
 
 @Data

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMUsageDrillDownResult.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/model/LLMUsageDrillDownResult.java
@@ -1,4 +1,4 @@
-package ai.gebo.llms.chat.client.rest.model;
+package ai.gebo.architecture.llms.usage.model;
 
 import java.util.List;
 

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/repository/LLMDailyUsageDetailRepository.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/repository/LLMDailyUsageDetailRepository.java
@@ -1,11 +1,11 @@
-package ai.gebo.llms.abstraction.layer.repository;
+package ai.gebo.architecture.llms.usage.repository;
 
 import java.util.Optional;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-import ai.gebo.llms.abstraction.layer.model.LLMDailyUsageDetail;
-import ai.gebo.llms.abstraction.layer.model.ModelType;
+import ai.gebo.architecture.llms.usage.model.LLMDailyUsageDetail;
+import ai.gebo.model.ModelType;
 
 public interface LLMDailyUsageDetailRepository extends MongoRepository<LLMDailyUsageDetail, String> {
 

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/repository/LLMUsageDetailRepository.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/repository/LLMUsageDetailRepository.java
@@ -1,11 +1,11 @@
-package ai.gebo.llms.abstraction.layer.repository;
+package ai.gebo.architecture.llms.usage.repository;
 
 import java.util.stream.Stream;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
-import ai.gebo.llms.abstraction.layer.model.LLMUsageDetail;
+import ai.gebo.architecture.llms.usage.model.LLMUsageDetail;
 
 public interface LLMUsageDetailRepository extends MongoRepository<LLMUsageDetail, String> {
 	/**

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/service/impl/LLMSUsageAggregationService.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/service/impl/LLMSUsageAggregationService.java
@@ -1,4 +1,4 @@
-package ai.gebo.llms.chat.client.rest.services;
+package ai.gebo.architecture.llms.usage.service.impl;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -14,11 +14,11 @@ import org.springframework.data.mongodb.core.aggregation.ProjectionOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Service;
 
-import ai.gebo.llms.abstraction.layer.model.LLMDailyUsageDetail;
-import ai.gebo.llms.chat.client.rest.model.LLMUsageAggregationBucket;
-import ai.gebo.llms.chat.client.rest.model.LLMUsageDrillDownLevel;
-import ai.gebo.llms.chat.client.rest.model.LLMUsageDrillDownLevelSubdimensions;
-import ai.gebo.llms.chat.client.rest.model.LLMUsageDrillDownResult;
+import ai.gebo.architecture.llms.usage.model.LLMDailyUsageDetail;
+import ai.gebo.architecture.llms.usage.model.LLMUsageAggregationBucket;
+import ai.gebo.architecture.llms.usage.model.LLMUsageDrillDownLevel;
+import ai.gebo.architecture.llms.usage.model.LLMUsageDrillDownLevelSubdimensions;
+import ai.gebo.architecture.llms.usage.model.LLMUsageDrillDownResult;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/service/impl/LLMUsageConcentratorReceiverFactory.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/service/impl/LLMUsageConcentratorReceiverFactory.java
@@ -1,0 +1,100 @@
+package ai.gebo.architecture.llms.usage.service.impl;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import ai.gebo.application.messaging.GAbstractMessageReceiverFactory;
+import ai.gebo.application.messaging.IGMessageReceiver;
+import ai.gebo.application.messaging.SystemComponentType;
+import ai.gebo.application.messaging.model.GMessageEnvelope;
+import ai.gebo.application.messaging.model.GStandardModulesConstraints;
+import ai.gebo.architecture.llms.usage.model.LLMUsageDetail;
+import ai.gebo.architecture.llms.usage.repository.LLMUsageDetailRepository;
+import ai.gebo.architecture.patterns.IGRuntimeBinder;
+import ai.gebo.core.messages.LLMUsageDetailPayload;
+
+/**
+ * Receives {@link LLMUsageDetailPayload} emitted by every LLM-hosting
+ * microservice's {@code LLMSUsageCrudServiceImpl} and persists it - the raw
+ * insert previously done synchronously in that emitter, now offloaded to this
+ * receiver's own dedicated thread (pool cardinality 1), mirroring
+ * {@code GComputeEndOfWorkflowReceiverFactory} in the sibling
+ * {@code ai.gebo.workflows.compute.service.impl} package.
+ */
+@Component
+@Scope("singleton")
+public class LLMUsageConcentratorReceiverFactory extends GAbstractMessageReceiverFactory {
+	private final IGRuntimeBinder runtimeBinder;
+	public static final MessageReceiverFactoryConfig factoryConfig = new MessageReceiverFactoryConfig();
+
+	static {
+		factoryConfig.setUseSenderThread(false);
+		factoryConfig.setPoolCardinality(1);
+	}
+
+	class UsageNestedReceiver extends GNestedMessageReceiver {
+
+		@Override
+		public void accept(GMessageEnvelope t) {
+			if (t.getPayload() instanceof LLMUsageDetailPayload payload) {
+				LLMUsageDetailRepository usageRepo = runtimeBinder.getImplementationOf(LLMUsageDetailRepository.class);
+				usageRepo.insert(toEntity(payload));
+			} else {
+				throw new IllegalStateException("This receiver cannot handle payload type:" + t.getPayloadType());
+			}
+		}
+
+		private LLMUsageDetail toEntity(LLMUsageDetailPayload payload) {
+			LLMUsageDetail detail = new LLMUsageDetail();
+			detail.setProviderId(payload.getProviderId());
+			detail.setUsername(payload.getUsername());
+			detail.setModel(payload.getModel());
+			detail.setCallerStack(payload.getCallerStack());
+			detail.setModelType(payload.getModelType());
+			detail.setLatency(payload.getLatency());
+			detail.setInputToken(payload.getInputToken());
+			detail.setOutputToken(payload.getOutputToken());
+			detail.setTotalToken(payload.getTotalToken());
+			detail.setTimestamp(payload.getUsageTimestamp());
+			return detail;
+		}
+	}
+
+	public LLMUsageConcentratorReceiverFactory(IGRuntimeBinder runtimeBinder) {
+		super(factoryConfig);
+		this.runtimeBinder = runtimeBinder;
+	}
+
+	@Override
+	public List<String> getAcceptedPayloadTypes() {
+		return List.of(LLMUsageDetailPayload.class.getName());
+	}
+
+	@Override
+	public boolean isAcceptEveryPayloadType() {
+		return false;
+	}
+
+	@Override
+	public IGMessageReceiver create() {
+		return new UsageNestedReceiver();
+	}
+
+	@Override
+	public String getMessagingModuleId() {
+		return GStandardModulesConstraints.LLMS_USAGE_MONITOR;
+	}
+
+	@Override
+	public String getMessagingSystemId() {
+		return GStandardModulesConstraints.USAGE_CONCENTRATOR;
+	}
+
+	@Override
+	public SystemComponentType getComponentType() {
+		return SystemComponentType.APPLICATION_COMPONENT;
+	}
+
+}

--- a/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/service/impl/LLMUsageDailyAggregationServiceImpl.java
+++ b/gebo.architecture.parent/gebo.architecture.compute.workflow/src/main/java/ai/gebo/architecture/llms/usage/service/impl/LLMUsageDailyAggregationServiceImpl.java
@@ -1,0 +1,135 @@
+package ai.gebo.architecture.llms.usage.service.impl;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import ai.gebo.architecture.llms.usage.model.LLMDailyUsageDetail;
+import ai.gebo.architecture.llms.usage.model.LLMUsageDetail;
+import ai.gebo.architecture.llms.usage.repository.LLMDailyUsageDetailRepository;
+import ai.gebo.architecture.llms.usage.repository.LLMUsageDetailRepository;
+import ai.gebo.model.ModelType;
+import lombok.AllArgsConstructor;
+
+/**
+ * Periodically folds raw {@link LLMUsageDetail} rows written by
+ * {@link LLMUsageConcentratorReceiverFactory} into {@link LLMDailyUsageDetail}
+ * daily aggregates. Moved verbatim from the old
+ * {@code LLMSUsageCrudServiceImpl.consolidateTick()} in
+ * {@code gebo.architecture.llms.abstraction.layer}.
+ */
+@Component
+@AllArgsConstructor
+public class LLMUsageDailyAggregationServiceImpl {
+	private final LLMUsageDetailRepository usageRepo;
+	private final LLMDailyUsageDetailRepository consolidatedRepo;
+
+	@Scheduled(initialDelay = 5000, fixedRate = 10 * 60 * 1000)
+	public void consolidateTick() {
+		ZoneId zone = ZoneId.systemDefault();
+		LocalDate today = LocalDate.now(zone);
+
+		// Only completed days are consolidated: everything up to the last
+		// millisecond of yesterday.
+		long lastMillisOfYesterday = today.atStartOfDay(zone).toInstant().toEpochMilli() - 1;
+		long todayFirstMillisecond = lastMillisOfYesterday + 1;
+		long todayLastMillisecond = today.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli() - 1;
+		;
+		// Aggregate the raw values grouping by
+		// providerId, username, model, callerStack, modelType, year, month, day.
+		Map<ConsolidationKey, DailyAccumulator> grouped = new HashMap<>();
+		try (Stream<LLMUsageDetail> stream = usageRepo.findByTimestampGreaterThanEqualAndTimestampLessThanEqual(
+				todayFirstMillisecond, todayLastMillisecond)) {
+			stream.forEach(detail -> {
+				LocalDate date = Instant.ofEpochMilli(detail.getTimestamp()).atZone(zone).toLocalDate();
+				ConsolidationKey key = new ConsolidationKey(detail.getProviderId(), detail.getUsername(),
+						detail.getModel(), detail.getCallerStack(), detail.getModelType(), date.getYear(),
+						date.getMonthValue(), date.getDayOfMonth());
+				grouped.computeIfAbsent(key, k -> new DailyAccumulator()).add(detail);
+			});
+		}
+		if (grouped.isEmpty()) {
+			return;
+		}
+
+		// Complete the sums of the target daily documents, merging into any
+		// previously consolidated record for the same key.
+		for (Map.Entry<ConsolidationKey, DailyAccumulator> entry : grouped.entrySet()) {
+			ConsolidationKey key = entry.getKey();
+			LLMDailyUsageDetail target = consolidatedRepo
+					.findByProviderIdAndUsernameAndModelAndCallerStackAndModelTypeAndYearAndMonthAndDay(
+							key.providerId(), key.username(), key.model(), key.callerStack(), key.modelType(),
+							key.year(), key.month(), key.day())
+					.orElseGet(() -> newDailyUsageDetail(key));
+			entry.getValue().mergeInto(target);
+			consolidatedRepo.save(target);
+		}
+
+		// The processed raw details have been folded into the daily documents,
+		// remove every detail belonging to an already-consolidated day.
+		usageRepo.deleteByTimestampLessThanEqual(lastMillisOfYesterday);
+	}
+
+	private static LLMDailyUsageDetail newDailyUsageDetail(ConsolidationKey key) {
+		LLMDailyUsageDetail daily = new LLMDailyUsageDetail();
+		daily.setProviderId(key.providerId());
+		daily.setUsername(key.username());
+		daily.setModel(key.model());
+		daily.setCallerStack(key.callerStack());
+		daily.setModelType(key.modelType());
+		daily.setYear(key.year());
+		daily.setMonth(key.month());
+		daily.setDay(key.day());
+		return daily;
+	}
+
+	private record ConsolidationKey(String providerId, String username, String model, String callerStack,
+			ModelType modelType, int year, int month, int day) {
+	}
+
+	private static final class DailyAccumulator {
+		private long inputToken;
+		private long outputToken;
+		private long totalToken;
+		private long nrRequests;
+		private long latencySum;
+		private long latencyMin = Long.MAX_VALUE;
+		private long latencyMax = Long.MIN_VALUE;
+
+		void add(LLMUsageDetail detail) {
+			inputToken += detail.getInputToken();
+			outputToken += detail.getOutputToken();
+			totalToken += detail.getTotalToken();
+			nrRequests++;
+			latencySum += detail.getLatency();
+			latencyMin = Math.min(latencyMin, detail.getLatency());
+			latencyMax = Math.max(latencyMax, detail.getLatency());
+		}
+
+		void mergeInto(LLMDailyUsageDetail target) {
+			long existingNr = target.getNrRequests();
+			long existingLatencySum = target.getLatencyAvg() * existingNr;
+			long combinedNr = existingNr + nrRequests;
+
+			target.setInputToken(target.getInputToken() + inputToken);
+			target.setOutputToken(target.getOutputToken() + outputToken);
+			target.setTotalToken(target.getTotalToken() + totalToken);
+			target.setNrRequests(combinedNr);
+			target.setLatencyAvg(combinedNr > 0 ? (existingLatencySum + latencySum) / combinedNr : 0);
+			if (existingNr > 0) {
+				target.setLatencyMin(Math.min(target.getLatencyMin(), latencyMin));
+				target.setLatencyMax(Math.max(target.getLatencyMax(), latencyMax));
+			} else {
+				target.setLatencyMin(latencyMin);
+				target.setLatencyMax(latencyMax);
+			}
+		}
+	}
+
+}

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/pom.xml
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/pom.xml
@@ -64,6 +64,16 @@
 			<artifactId>gebo.ranker.api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>ai.gebo.architecture</groupId>
+			<artifactId>gebo.application.messaging</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ai.gebo.core</groupId>
+			<artifactId>gebo.core.messages</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/dto/LLMUsageDetailDto.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/dto/LLMUsageDetailDto.java
@@ -1,20 +1,24 @@
-package ai.gebo.llms.abstraction.layer.model;
+package ai.gebo.llms.abstraction.layer.dto;
 
-import java.util.UUID;
-
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.index.HashIndexed;
-import org.springframework.data.mongodb.core.mapping.Document;
-
+import ai.gebo.llms.abstraction.layer.model.GBaseChatModelConfig;
+import ai.gebo.llms.abstraction.layer.model.GBaseEmbeddingModelConfig;
+import ai.gebo.llms.abstraction.layer.model.GBaseImageModelConfig;
+import ai.gebo.llms.abstraction.layer.model.GBaseModelConfig;
+import ai.gebo.llms.abstraction.layer.model.GBaseRankerModelConfig;
+import ai.gebo.llms.abstraction.layer.model.GBaseTextToSpeachModelConfig;
+import ai.gebo.llms.abstraction.layer.model.GBaseTranscriptModelConfig;
+import ai.gebo.model.ModelType;
 import lombok.Data;
 
+/**
+ * Public-API shape of {@code ILLMSUsageCrudService.enqueueUsage(...)}, decoupling
+ * callers (the usage advisor) from both the persistence entity and the internal
+ * messaging payload, which now live in {@code gebo.architecture.compute.workflow}
+ * and {@code gebo.core.messages} respectively.
+ */
 @Data
-@Document
-public class LLMUsageDetail {
+public class LLMUsageDetailDto {
 	private static final String UNKNOWN = "unknown";
-
-	@Id
-	private String id = UUID.randomUUID().toString();
 
 	private String providerId;
 	private String username;
@@ -25,11 +29,9 @@ public class LLMUsageDetail {
 	private long inputToken;
 	private long outputToken;
 	private long totalToken;
-	@HashIndexed
-	private long timestamp = System.currentTimeMillis();
 
-	public static LLMUsageDetail of(GBaseModelConfig config) {
-		LLMUsageDetail detail = new LLMUsageDetail();
+	public static LLMUsageDetailDto of(GBaseModelConfig config) {
+		LLMUsageDetailDto detail = new LLMUsageDetailDto();
 		if (config != null && config.getModelTypeCode() != null) {
 			detail.setProviderId(config.getModelTypeCode());
 		} else

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/model/ModelType.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/model/ModelType.java
@@ -1,5 +1,0 @@
-package ai.gebo.llms.abstraction.layer.model;
-
-public enum ModelType {
-	CHAT, EMBEDDING, IMAGE, RANKER, TTS, TRANSCRIPT
-}

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/services/ILLMSUsageCrudService.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/services/ILLMSUsageCrudService.java
@@ -1,10 +1,7 @@
 package ai.gebo.llms.abstraction.layer.services;
 
-import org.springframework.scheduling.annotation.Async;
-
-import ai.gebo.llms.abstraction.layer.model.LLMUsageDetail;
+import ai.gebo.llms.abstraction.layer.dto.LLMUsageDetailDto;
 
 public interface ILLMSUsageCrudService {
-	@Async
-	public void enqueueUsage(LLMUsageDetail usage);
+	public void enqueueUsage(LLMUsageDetailDto usage);
 }

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/services/impl/LLMSUsageCrudServiceImpl.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/services/impl/LLMSUsageCrudServiceImpl.java
@@ -1,137 +1,70 @@
 package ai.gebo.llms.abstraction.layer.services.impl;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Stream;
+import java.util.List;
 
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import ai.gebo.llms.abstraction.layer.model.LLMDailyUsageDetail;
-import ai.gebo.llms.abstraction.layer.model.LLMUsageDetail;
-import ai.gebo.llms.abstraction.layer.model.ModelType;
-import ai.gebo.llms.abstraction.layer.repository.LLMDailyUsageDetailRepository;
-import ai.gebo.llms.abstraction.layer.repository.LLMUsageDetailRepository;
+import ai.gebo.application.messaging.IGMessageBroker;
+import ai.gebo.application.messaging.IGMessageEmitter;
+import ai.gebo.application.messaging.IMessageEnvelopeFactory;
+import ai.gebo.application.messaging.SystemComponentType;
+import ai.gebo.application.messaging.model.GMessageEnvelope;
+import ai.gebo.application.messaging.model.GStandardModulesConstraints;
+import ai.gebo.core.messages.LLMUsageDetailPayload;
+import ai.gebo.llms.abstraction.layer.dto.LLMUsageDetailDto;
 import ai.gebo.llms.abstraction.layer.services.ILLMSUsageCrudService;
 import lombok.AllArgsConstructor;
 
+/**
+ * Emits usage events to the {@code LLMS-USAGE-MONITOR}/{@code USAGE-CONCENTRATOR}
+ * receiver hosted in {@code gebo.architecture.compute.workflow} (package
+ * {@code ai.gebo.architecture.llms.usage}), rather than persisting directly - the
+ * receiver's own dedicated thread does the Mongo write and the periodic
+ * consolidation, keeping both off the calling chat-completion thread.
+ */
 @Service
 @AllArgsConstructor
-public class LLMSUsageCrudServiceImpl implements ILLMSUsageCrudService {
-	private final LLMUsageDetailRepository usageRepo;
-	private final LLMDailyUsageDetailRepository consolidatedRepo;
+public class LLMSUsageCrudServiceImpl implements ILLMSUsageCrudService, IGMessageEmitter {
+	private final IGMessageBroker broker;
+	private final IMessageEnvelopeFactory envelopeFactory;
 
 	@Override
-	@Async
-	public void enqueueUsage(LLMUsageDetail usage) {
-		usageRepo.insert(usage);
+	public void enqueueUsage(LLMUsageDetailDto usage) {
+		LLMUsageDetailPayload payload = new LLMUsageDetailPayload();
+		payload.setProviderId(usage.getProviderId());
+		payload.setUsername(usage.getUsername());
+		payload.setModel(usage.getModel());
+		payload.setCallerStack(usage.getCallerStack());
+		payload.setModelType(usage.getModelType());
+		payload.setLatency(usage.getLatency());
+		payload.setInputToken(usage.getInputToken());
+		payload.setOutputToken(usage.getOutputToken());
+		payload.setTotalToken(usage.getTotalToken());
+		payload.setUsageTimestamp(System.currentTimeMillis());
+
+		GMessageEnvelope<LLMUsageDetailPayload> envelope = envelopeFactory.newMessageFrom(this, payload);
+		envelope.setTargetModule(GStandardModulesConstraints.LLMS_USAGE_MONITOR);
+		envelope.setTargetComponent(GStandardModulesConstraints.USAGE_CONCENTRATOR);
+		broker.accept(envelope);
 	}
 
-	@Scheduled(initialDelay = 5000, fixedRate = 10 * 60 * 1000)
-	public void consolidateTick() {
-		ZoneId zone = ZoneId.systemDefault();
-		LocalDate today = LocalDate.now(zone);
-
-		// Only completed days are consolidated: everything up to the last
-		// millisecond of yesterday.
-		long lastMillisOfYesterday = today.atStartOfDay(zone).toInstant().toEpochMilli() - 1;
-		long todayFirstMillisecond = lastMillisOfYesterday + 1;
-		long todayLastMillisecond = today.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli() - 1;
-		;
-		// Aggregate the raw values grouping by
-		// providerId, username, model, callerStack, modelType, year, month, day.
-		Map<ConsolidationKey, DailyAccumulator> grouped = new HashMap<>();
-		try (Stream<LLMUsageDetail> stream = usageRepo.findByTimestampGreaterThanEqualAndTimestampLessThanEqual(
-				todayFirstMillisecond, todayLastMillisecond)) {
-			stream.forEach(detail -> {
-				LocalDate date = Instant.ofEpochMilli(detail.getTimestamp()).atZone(zone).toLocalDate();
-				ConsolidationKey key = new ConsolidationKey(detail.getProviderId(), detail.getUsername(),
-						detail.getModel(), detail.getCallerStack(), detail.getModelType(), date.getYear(),
-						date.getMonthValue(), date.getDayOfMonth());
-				grouped.computeIfAbsent(key, k -> new DailyAccumulator()).add(detail);
-			});
-		}
-		if (grouped.isEmpty()) {
-			return;
-		}
-
-		// Complete the sums of the target daily documents, merging into any
-		// previously consolidated record for the same key.
-		for (Map.Entry<ConsolidationKey, DailyAccumulator> entry : grouped.entrySet()) {
-			ConsolidationKey key = entry.getKey();
-			LLMDailyUsageDetail target = consolidatedRepo
-					.findByProviderIdAndUsernameAndModelAndCallerStackAndModelTypeAndYearAndMonthAndDay(
-							key.providerId(), key.username(), key.model(), key.callerStack(), key.modelType(),
-							key.year(), key.month(), key.day())
-					.orElseGet(() -> newDailyUsageDetail(key));
-			entry.getValue().mergeInto(target);
-			consolidatedRepo.save(target);
-		}
-
-		// The processed raw details have been folded into the daily documents,
-		// remove every detail belonging to an already-consolidated day.
-		usageRepo.deleteByTimestampLessThanEqual(lastMillisOfYesterday);
+	@Override
+	public String getMessagingModuleId() {
+		return GStandardModulesConstraints.LLMS_USAGE_MONITOR;
 	}
 
-	private static LLMDailyUsageDetail newDailyUsageDetail(ConsolidationKey key) {
-		LLMDailyUsageDetail daily = new LLMDailyUsageDetail();
-		daily.setProviderId(key.providerId());
-		daily.setUsername(key.username());
-		daily.setModel(key.model());
-		daily.setCallerStack(key.callerStack());
-		daily.setModelType(key.modelType());
-		daily.setYear(key.year());
-		daily.setMonth(key.month());
-		daily.setDay(key.day());
-		return daily;
+	@Override
+	public String getMessagingSystemId() {
+		return GStandardModulesConstraints.USAGE_CONCENTRATOR;
 	}
 
-	private record ConsolidationKey(String providerId, String username, String model, String callerStack,
-			ModelType modelType, int year, int month, int day) {
+	@Override
+	public SystemComponentType getComponentType() {
+		return SystemComponentType.APPLICATION_COMPONENT;
 	}
 
-	private static final class DailyAccumulator {
-		private long inputToken;
-		private long outputToken;
-		private long totalToken;
-		private long nrRequests;
-		private long latencySum;
-		private long latencyMin = Long.MAX_VALUE;
-		private long latencyMax = Long.MIN_VALUE;
-
-		void add(LLMUsageDetail detail) {
-			inputToken += detail.getInputToken();
-			outputToken += detail.getOutputToken();
-			totalToken += detail.getTotalToken();
-			nrRequests++;
-			latencySum += detail.getLatency();
-			latencyMin = Math.min(latencyMin, detail.getLatency());
-			latencyMax = Math.max(latencyMax, detail.getLatency());
-		}
-
-		void mergeInto(LLMDailyUsageDetail target) {
-			long existingNr = target.getNrRequests();
-			long existingLatencySum = target.getLatencyAvg() * existingNr;
-			long combinedNr = existingNr + nrRequests;
-
-			target.setInputToken(target.getInputToken() + inputToken);
-			target.setOutputToken(target.getOutputToken() + outputToken);
-			target.setTotalToken(target.getTotalToken() + totalToken);
-			target.setNrRequests(combinedNr);
-			target.setLatencyAvg(combinedNr > 0 ? (existingLatencySum + latencySum) / combinedNr : 0);
-			if (existingNr > 0) {
-				target.setLatencyMin(Math.min(target.getLatencyMin(), latencyMin));
-				target.setLatencyMax(Math.max(target.getLatencyMax(), latencyMax));
-			} else {
-				target.setLatencyMin(latencyMin);
-				target.setLatencyMax(latencyMax);
-			}
-		}
+	@Override
+	public List<String> getEmittedPayloadTypes() {
+		return List.of(LLMUsageDetailPayload.class.getName());
 	}
-
 }

--- a/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/services/impl/UsageAdvisorFactoryImpl.java
+++ b/gebo.architecture.parent/gebo.architecture.llms.abstraction.layer/src/main/java/ai/gebo/llms/abstraction/layer/services/impl/UsageAdvisorFactoryImpl.java
@@ -13,8 +13,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import ai.gebo.llms.abstraction.layer.dto.LLMUsageDetailDto;
 import ai.gebo.llms.abstraction.layer.model.GBaseChatModelConfig;
-import ai.gebo.llms.abstraction.layer.model.LLMUsageDetail;
 import ai.gebo.llms.abstraction.layer.services.IChatModelUsageAdvisor;
 import ai.gebo.llms.abstraction.layer.services.IChatModelUsageAdvisorFactory;
 import ai.gebo.llms.abstraction.layer.services.ILLMSUsageCrudService;
@@ -81,12 +81,13 @@ public class UsageAdvisorFactoryImpl implements IChatModelUsageAdvisorFactory {
 			Integer inputTokens = usage.getPromptTokens();
 			Integer outputTokens = usage.getCompletionTokens();
 			Integer totalTokens = usage.getTotalTokens();
-			LLMUsageDetail detail = LLMUsageDetail.of(config);
+			LLMUsageDetailDto detail = LLMUsageDetailDto.of(config);
 			detail.setInputToken(inputTokens != null ? inputTokens.longValue() : 0l);
 			detail.setOutputToken(outputTokens != null ? outputTokens.longValue() : 0l);
 			detail.setTotalToken(totalTokens != null ? totalTokens.longValue() : 0l);
 			detail.setUsername(username);
 			detail.setCallerStack(callStack);
+			detail.setLatency(latencyMs);
 			this.usageCrudService.enqueueUsage(detail);
 		}
 	}

--- a/gebo.architecture.parent/gebo.architecture.rag.support.layer/pom.xml
+++ b/gebo.architecture.parent/gebo.architecture.rag.support.layer/pom.xml
@@ -16,7 +16,22 @@
 		</dependency>
 		<dependency>
 			<groupId>ai.gebo.architecture</groupId>
-			<artifactId>gebo.architecture.contentsystems.abstraction.layer</artifactId>
+			<artifactId>gebo.architecture.documents.access</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ai.gebo.architecture</groupId>
+			<artifactId>gebo.architecture.contenthandling.interfaces</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ai.gebo</groupId>
+			<artifactId>gebo.system.ingestion</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ai.gebo.core</groupId>
+			<artifactId>gebo.knowledgebase.repositories</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>

--- a/gebo.architecture.parent/gebo.architecture.rag.support.layer/src/main/java/ai/gebo/architecture/rag/support/layer/model/AIDocumentReferenceItem.java
+++ b/gebo.architecture.parent/gebo.architecture.rag.support.layer/src/main/java/ai/gebo/architecture/rag/support/layer/model/AIDocumentReferenceItem.java
@@ -9,8 +9,6 @@
 
 package ai.gebo.architecture.rag.support.layer.model;
 
-import static org.mockito.Mockito.framework;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/gebo.architecture.parent/gebo.architecture.rag.support.layer/src/main/java/ai/gebo/architecture/rag/support/layer/services/IGAIDocumentsCacheService.java
+++ b/gebo.architecture.parent/gebo.architecture.rag.support.layer/src/main/java/ai/gebo/architecture/rag/support/layer/services/IGAIDocumentsCacheService.java
@@ -2,9 +2,9 @@ package ai.gebo.architecture.rag.support.layer.services;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import ai.gebo.architecture.contenthandling.interfaces.GeboContentHandlerSystemException;
+import ai.gebo.architecture.documents.access.DocumentContentStreamerException;
 import ai.gebo.architecture.persistence.GeboPersistenceException;
 import ai.gebo.architecture.rag.support.layer.model.AIDocumentCacheItem;
 import ai.gebo.architecture.rag.support.layer.model.AIDocumentReferenceItem;
@@ -13,24 +13,23 @@ import ai.gebo.knlowledgebase.model.contents.GDocumentReference;
 import ai.gebo.knlowledgebase.model.projects.GProjectEndpoint;
 import ai.gebo.model.base.GObjectRef;
 import ai.gebo.system.ingestion.GeboIngestionException;
-import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
 
 public interface IGAIDocumentsCacheService {
 	public void addCachedOrRetrieve(GObjectRef<GProjectEndpoint> objectRef, List<GDocumentReference> docList,
-			AIDocumentsSet result)
-			throws GeboPersistenceException, GeboContentHandlerSystemException, IOException, GeboIngestionException;
+			AIDocumentsSet result) throws GeboPersistenceException, GeboContentHandlerSystemException, IOException,
+			GeboIngestionException, DocumentContentStreamerException;
 
-	public void addCacheOrRetrieve(GDocumentReference document, IGContentManagementSystemHandler handler,
-			GProjectEndpoint endpoint, AIDocumentsSet result, Map handlerWorkCache)
-			throws GeboContentHandlerSystemException, IOException, GeboIngestionException, GeboPersistenceException;
+	public void addCacheOrRetrieve(GDocumentReference document, AIDocumentsSet result)
+			throws GeboContentHandlerSystemException, IOException, GeboIngestionException, GeboPersistenceException,
+			DocumentContentStreamerException;
 
 	public void addToRetrieved(AIDocumentCacheItem cacheItem, GDocumentReference document, AIDocumentsSet result);
 
-	public void loadAddCacheAndAddToRetrieved(GDocumentReference document, IGContentManagementSystemHandler handler,
-			GProjectEndpoint endpoint, AIDocumentsSet result, Map handlerWorkCache)
-			throws GeboContentHandlerSystemException, IOException, GeboIngestionException, GeboPersistenceException;
+	public void loadAddCacheAndAddToRetrieved(GDocumentReference document, AIDocumentsSet result)
+			throws GeboContentHandlerSystemException, IOException, GeboIngestionException, GeboPersistenceException,
+			DocumentContentStreamerException;
 
-	public AIDocumentReferenceItem retrieve(GDocumentReference document)
-			throws GeboPersistenceException, GeboContentHandlerSystemException, IOException, GeboIngestionException;
+	public AIDocumentReferenceItem retrieve(GDocumentReference document) throws GeboPersistenceException,
+			GeboContentHandlerSystemException, IOException, GeboIngestionException, DocumentContentStreamerException;
 
 }

--- a/gebo.architecture.parent/gebo.architecture.rag.support.layer/src/main/java/ai/gebo/architecture/rag/support/layer/services/impl/AIDocumentsCacheService.java
+++ b/gebo.architecture.parent/gebo.architecture.rag.support.layer/src/main/java/ai/gebo/architecture/rag/support/layer/services/impl/AIDocumentsCacheService.java
@@ -10,10 +10,7 @@
 package ai.gebo.architecture.rag.support.layer.services.impl;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.ai.document.Document;
@@ -21,6 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import ai.gebo.architecture.contenthandling.interfaces.GeboContentHandlerSystemException;
+import ai.gebo.architecture.documents.access.DocumentContentStreamerException;
+import ai.gebo.architecture.documents.access.IGDocumentContentStreamer;
 import ai.gebo.architecture.documents.access.StreamingPurpose;
 import ai.gebo.architecture.persistence.GeboPersistenceException;
 import ai.gebo.architecture.persistence.IGPersistentObjectManager;
@@ -40,8 +39,6 @@ import ai.gebo.model.base.TypedInputStream;
 import ai.gebo.system.ingestion.GeboIngestionException;
 import ai.gebo.system.ingestion.IGDocumentReferenceIngestionHandler;
 import ai.gebo.system.ingestion.IGDocumentReferenceIngestionHandler.IngestionHandlerData;
-import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
-import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandlerRepositoryPattern;
 import lombok.AllArgsConstructor;
 
 /**
@@ -58,7 +55,7 @@ public class AIDocumentsCacheService implements IGAIDocumentsCacheService {
 	// Inject dependencies
 	final IGPersistentObjectManager persistentObject;
 
-	final IGContentManagementSystemHandlerRepositoryPattern contentSystemHandlersPattern;
+	final IGDocumentContentStreamer streamer;
 
 	final RagDocumentCacheItemRepository cacheItemsRepository;
 
@@ -76,26 +73,23 @@ public class AIDocumentsCacheService implements IGAIDocumentsCacheService {
 	 * @throws GeboContentHandlerSystemException
 	 * @throws IOException
 	 * @throws GeboIngestionException
+	 * @throws DocumentContentStreamerException
 	 */
 	public void addCachedOrRetrieve(GObjectRef<GProjectEndpoint> objectRef, List<GDocumentReference> docList,
-			AIDocumentsSet result)
-			throws GeboPersistenceException, GeboContentHandlerSystemException, IOException, GeboIngestionException {
+			AIDocumentsSet result) throws GeboPersistenceException, GeboContentHandlerSystemException, IOException,
+			GeboIngestionException, DocumentContentStreamerException {
 		// Retrieve the project endpoint
 		GProjectEndpoint endpoint = this.persistentObject.findByReference(objectRef, GProjectEndpoint.class);
 		if (endpoint != null) {
-			Map handlerWorkCache = new HashMap();
-			IGContentManagementSystemHandler handler = contentSystemHandlersPattern.findByHandledEndpoint(endpoint);
-			if (handler != null) {
-				// Process each document reference
-				for (GDocumentReference document : docList) {
-					addCacheOrRetrieve(document, handler, endpoint, result, handlerWorkCache);
-				}
+			// Process each document reference
+			for (GDocumentReference document : docList) {
+				addCacheOrRetrieve(document, result);
 			}
 		}
 	}
 
-	public AIDocumentReferenceItem retrieve(GDocumentReference document)
-			throws GeboPersistenceException, GeboContentHandlerSystemException, IOException, GeboIngestionException {
+	public AIDocumentReferenceItem retrieve(GDocumentReference document) throws GeboPersistenceException,
+			GeboContentHandlerSystemException, IOException, GeboIngestionException, DocumentContentStreamerException {
 		AIDocumentsSet set = new AIDocumentsSet();
 		addCachedOrRetrieve(document.getProjectEndpointReference(), List.of(document), set);
 		if (!set.getDocumentItems().isEmpty())
@@ -105,20 +99,18 @@ public class AIDocumentsCacheService implements IGAIDocumentsCacheService {
 
 	/**
 	 * Checks if a document is in cache or needs to be loaded and cached.
-	 * 
-	 * @param document         Document reference
-	 * @param handler          Content management system handler
-	 * @param endpoint         Project endpoint
-	 * @param result           Result object to store retrieved document information
-	 * @param handlerWorkCache Cache for handler work
+	 *
+	 * @param document Document reference
+	 * @param result   Result object to store retrieved document information
 	 * @throws GeboContentHandlerSystemException
 	 * @throws IOException
 	 * @throws GeboIngestionException
 	 * @throws GeboPersistenceException
+	 * @throws DocumentContentStreamerException
 	 */
-	public void addCacheOrRetrieve(GDocumentReference document, IGContentManagementSystemHandler handler,
-			GProjectEndpoint endpoint, AIDocumentsSet result, Map handlerWorkCache)
-			throws GeboContentHandlerSystemException, IOException, GeboIngestionException, GeboPersistenceException {
+	public void addCacheOrRetrieve(GDocumentReference document, AIDocumentsSet result)
+			throws GeboContentHandlerSystemException, IOException, GeboIngestionException, GeboPersistenceException,
+			DocumentContentStreamerException {
 		// Check if the document is already in cache
 		Optional<AIDocumentCacheItem> entry = cacheItemsRepository.findById(document.getCode());
 		boolean load = true;
@@ -133,7 +125,7 @@ public class AIDocumentsCacheService implements IGAIDocumentsCacheService {
 		}
 		if (load) {
 			// Load and cache the document
-			loadAddCacheAndAddToRetrieved(document, handler, endpoint, result, handlerWorkCache);
+			loadAddCacheAndAddToRetrieved(document, result);
 		}
 	}
 
@@ -171,22 +163,23 @@ public class AIDocumentsCacheService implements IGAIDocumentsCacheService {
 	/**
 	 * Loads document content, caches it if necessary, and adds it to the retrieved
 	 * results.
-	 * 
-	 * @param document         Document reference
-	 * @param handler          Content management system handler
-	 * @param endpoint         Project endpoint
-	 * @param result           Result object to store retrieved document information
-	 * @param handlerWorkCache Cache for handler work
+	 *
+	 * @param document Document reference
+	 * @param result   Result object to store retrieved document information
 	 * @throws GeboContentHandlerSystemException
 	 * @throws IOException
 	 * @throws GeboIngestionException
 	 * @throws GeboPersistenceException
+	 * @throws DocumentContentStreamerException
 	 */
-	public void loadAddCacheAndAddToRetrieved(GDocumentReference document, IGContentManagementSystemHandler handler,
-			GProjectEndpoint endpoint, AIDocumentsSet result, Map handlerWorkCache)
-			throws GeboContentHandlerSystemException, IOException, GeboIngestionException, GeboPersistenceException {
-		// Stream content of the document
-		TypedInputStream is = handler.streamContent(StreamingPurpose.INGESTING, document, handlerWorkCache);
+	public void loadAddCacheAndAddToRetrieved(GDocumentReference document, AIDocumentsSet result)
+			throws GeboContentHandlerSystemException, IOException, GeboIngestionException, GeboPersistenceException,
+			DocumentContentStreamerException {
+		// Stream content of the document, resolved via IGDocumentContentStreamer
+		// (local on the monolith, chunker-proxying on microservices) rather than a
+		// locally co-located IGContentManagementSystemHandler, which only exists on
+		// the microservice that owns this document's content system.
+		TypedInputStream is = streamer.streamContent(StreamingPurpose.INGESTING, document);
 		// Handle content ingestion
 		IngestionHandlerData readData = ingestionHandler.handleContent(document, is);
 		if (!readData.isUnmanagedContent()) {

--- a/gebo.architecture.parent/gebo.architecture.rag.support.layer/src/main/java/ai/gebo/architecture/rag/support/layer/services/impl/GSemanticSearchDocumentsCachedDaoImpl.java
+++ b/gebo.architecture.parent/gebo.architecture.rag.support.layer/src/main/java/ai/gebo/architecture/rag/support/layer/services/impl/GSemanticSearchDocumentsCachedDaoImpl.java
@@ -52,7 +52,6 @@ import ai.gebo.security.model.UserInfos;
 import ai.gebo.security.services.IAclGrantedAccessorService;
 import ai.gebo.security.services.IGSecurityService;
 import ai.gebo.system.ingestion.IGDocumentReferenceIngestionHandler;
-import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandlerRepositoryPattern;
 import jakarta.el.MethodNotFoundException;
 
 /**
@@ -72,9 +71,6 @@ public class GSemanticSearchDocumentsCachedDaoImpl implements IGSemanticSearchDo
 
 	@Autowired
 	IGPersistentObjectManager persistentObject;
-
-	@Autowired
-	IGContentManagementSystemHandlerRepositoryPattern contentSystemHandlersPattern;
 
 	@Autowired
 	RagDocumentCacheItemRepository cacheItemsRepository;

--- a/gebo.core.parent/gebo.base.model/src/main/java/ai/gebo/model/ModelType.java
+++ b/gebo.core.parent/gebo.base.model/src/main/java/ai/gebo/model/ModelType.java
@@ -1,0 +1,14 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.model;
+
+public enum ModelType {
+	CHAT, EMBEDDING, IMAGE, RANKER, TTS, TRANSCRIPT
+}

--- a/gebo.core.parent/gebo.core.messages/src/main/java/ai/gebo/core/messages/LLMUsageDetailPayload.java
+++ b/gebo.core.parent/gebo.core.messages/src/main/java/ai/gebo/core/messages/LLMUsageDetailPayload.java
@@ -1,0 +1,37 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.core.messages;
+
+import ai.gebo.application.messaging.model.GBaseMessagePayload;
+import ai.gebo.model.ModelType;
+import lombok.Data;
+
+/**
+ * Carries one LLM call's usage detail from the emitting side
+ * ({@code LLMSUsageCrudServiceImpl}, {@code gebo.architecture.llms.abstraction.layer})
+ * to the {@code LLMS-USAGE-MONITOR}/{@code USAGE-CONCENTRATOR} receiver
+ * ({@code gebo.architecture.compute.workflow}). {@code usageTimestamp} is named
+ * distinctly from the inherited {@link #getTimestamp()} (envelope creation time)
+ * since it carries the actual epoch-millis of the LLM call, used by the receiver
+ * for the same range queries the old {@code LLMUsageDetail.timestamp} field served.
+ */
+@Data
+public class LLMUsageDetailPayload extends GBaseMessagePayload {
+	private String providerId;
+	private String username;
+	private String model;
+	private String callerStack;
+	private ModelType modelType;
+	private long latency;
+	private long inputToken;
+	private long outputToken;
+	private long totalToken;
+	private long usageTimestamp;
+}

--- a/gebo.ragsystem.parent/gebo.ragsystem.content.fulltext.processor/pom.xml
+++ b/gebo.ragsystem.parent/gebo.ragsystem.content.fulltext.processor/pom.xml
@@ -29,10 +29,5 @@
 			<artifactId>gebo.architecture.documents.cache</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>ai.gebo.architecture</groupId>
-			<artifactId>gebo.architecture.contentsystems.abstraction.layer</artifactId>
-			<version>${project.version}</version>
-		</dependency>
 	</dependencies>
 </project>

--- a/gebo.ragsystem.parent/gebo.ragsystem.content.graphrag_processor/src/main/java/ai/gebo/ragsystem/content/graphrag_processor/impl/GraphextractionProcessorBatchReceiver.java
+++ b/gebo.ragsystem.parent/gebo.ragsystem.content.graphrag_processor/src/main/java/ai/gebo/ragsystem/content/graphrag_processor/impl/GraphextractionProcessorBatchReceiver.java
@@ -1,7 +1,5 @@
 package ai.gebo.ragsystem.content.graphrag_processor.impl;
 
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/gebo.ragsystem.parent/gebo.ragsystem.content.vectorizator/pom.xml
+++ b/gebo.ragsystem.parent/gebo.ragsystem.content.vectorizator/pom.xml
@@ -27,11 +27,6 @@
 		</dependency> -->
 		<dependency>
 			<groupId>ai.gebo.architecture</groupId>
-			<artifactId>gebo.architecture.contentsystems.abstraction.layer</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>ai.gebo.architecture</groupId>
 			<artifactId>gebo.architecture.documents.cache</artifactId>
 			<version>${project.version}</version>
 		</dependency>


### PR DESCRIPTION
## Summary
- `LLMSUsageCrudServiceImpl` no longer writes to Mongo directly on the calling chat-completion thread. It emits a `LLMUsageDetailPayload` through the internal message broker (`LLMS-USAGE-MONITOR`/`USAGE-CONCENTRATOR`), matching the pattern already used for workflow/job-status consolidation.
- `LLMUsageDetail`/`LLMDailyUsageDetail`, their repositories, the daily consolidation job, the drill-down aggregation service, and the two admin/user reporting controllers move into a new `ai.gebo.architecture.llms.usage` package inside `gebo.architecture.compute.workflow`, off `gebo.ragsystem.client.rest` and `gebo.architecture.llms.abstraction.layer`.
- `ILLMSUsageCrudService.enqueueUsage` now takes a DTO instead of the entity; `ModelType` moves to `ai.gebo.model` (`gebo.base.model`) so it stays shared across the emitter, payload, and receiver-side entity without a circular dependency. Also fixes a pre-existing bug where the computed chat latency was never actually set on the outgoing usage record.
- Removed `brain.gebo.ai`'s leftover direct dependency on `gebo.architecture.compute.workflow` (zero source references to it, only there so its controllers got component-scanned onto brain). `gebo.architecture.compute.workflow` is now wired on exactly `tyr.gebo.ai` and the monolith.
- Added the same remote security/secrets/ACL client trio every other non-heimdall microservice gets to `tyr.gebo.ai`, needed once it started hosting `LLMSUsageUserLevelController` (which depends on `IGSecurityService` → `gebo.architecture.security`'s full config → `IGeboSecretsAccessService`).
- Regenerated `docs/MICROSERVICES-CONTROLLERS.md` from the live stack.

## Test plan
- [x] `mvn clean install` (full, with tests, 157 modules) — BUILD SUCCESS
- [x] `mvn -P docker,swagger-on clean package jib:buildTar -DskipTests` on all 20 microservice modules — BUILD SUCCESS
- [x] Full `docker-compose` stack brought up; all 18 controller-bearing services confirmed serving `/v3/api-docs`
- [x] `tyr` initially crash-looped from the security-client gap above; fixed, rebuilt, confirmed stable and serving `job-status-controller`, `workflow-stats-admin-level-controller`, `llms-usage-admin-level-controller`, `llms-usage-user-level-controller`
- [x] `brain` rebuilt without `compute.workflow`; confirmed it boots cleanly and no longer exposes any of those four controllers (226 → 221 endpoints)
- [x] Stack torn down cleanly