### PR TITLE
fix(graphrag-tests): fake extraction chat model returns LLMExtractionResult JSON

### DIFF
--- a/gebo.llms.parent/gebo.llms.tests.services/pom.xml
+++ b/gebo.llms.parent/gebo.llms.tests.services/pom.xml
@@ -14,5 +14,10 @@
 			<artifactId>gebo.architecture.testing</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>ai.gebo.architecture</groupId>
+			<artifactId>gebo.architecture.graphrag.extraction</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/gebo.llms.parent/gebo.llms.tests.services/src/main/java/ai/gebo/llms/abstraction/layer/tests/TestKnowledgeExtractionChatModel.java
+++ b/gebo.llms.parent/gebo.llms.tests.services/src/main/java/ai/gebo/llms/abstraction/layer/tests/TestKnowledgeExtractionChatModel.java
@@ -14,13 +14,18 @@ package ai.gebo.llms.abstraction.layer.tests;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 
+import ai.gebo.architecture.graphrag.extraction.model.LLMExtractionResult;
 import ai.gebo.architecture.testing.AbstractTestingBusinessLogic;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * AI generated comments
@@ -31,6 +36,10 @@ public class TestKnowledgeExtractionChatModel extends AbstractTestingBusinessLog
 	// Configuration object that contains the test response logic
 	TestKnowledgeExtractionModelConfiguration configuration = null;
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(TestKnowledgeExtractionChatModel.class);
+
+	private static final ObjectMapper JSON = new ObjectMapper();
+
 	/**
 	 * Default constructor for TestChatModel
 	 */
@@ -40,20 +49,64 @@ public class TestKnowledgeExtractionChatModel extends AbstractTestingBusinessLog
 
 	/**
 	 * Processes a prompt and returns a chat response based on configured test logic.
-	 * If no configuration is provided, returns an empty response.
-	 * 
+	 *
+	 * <p>
+	 * When the graphrag JSON extraction path is exercised, Spring AI's
+	 * {@code DefaultChatClient$DefaultCallResponseSpec.entity(Class<T>)} drives the
+	 * call through {@link #call(Prompt)} and then deserializes the assistant content
+	 * with {@code BeanOutputConverter<LLMExtractionResult>}. To keep that real
+	 * structured-output path working under the fake LLM, this method first consults
+	 * the configuration's {@code responseObjects} / {@code responseCallbacks} for a
+	 * canned {@link LLMExtractionResult} and, when present, serializes it to JSON so
+	 * the converter can parse it. Only when no canned extraction result is wired does
+	 * it fall back to the plain {@code testResponseLogic}.
+	 * </p>
+	 *
 	 * @param prompt The input prompt to process
 	 * @return A ChatResponse containing the generated response
 	 */
 	@Override
 	public ChatResponse call(Prompt prompt) {
 		String content = prompt.getContents();
-		String response = configuration != null && configuration.getTestResponseLogic() != null
-				? configuration.getTestResponseLogic().apply(content)
-				: "";
-		AssistantMessage am = new AssistantMessage(response);
+		String response = produceExtractionJsonResponse(prompt);
+		if (response == null) {
+			response = configuration != null && configuration.getTestResponseLogic() != null
+					? configuration.getTestResponseLogic().apply(content)
+					: "";
+		}
+		AssistantMessage am = new AssistantMessage(response != null ? response : "");
 		Generation generation = new Generation(am);
 		return new ChatResponse(List.of(generation));
+	}
+
+	/**
+	 * Resolves a canned {@link LLMExtractionResult} from the configuration (either a
+	 * static object in {@code responseObjects} or produced by a
+	 * {@code responseCallbacks} entry fed with the prompt's messages) and serializes
+	 * it to JSON for the structured-output converter. Returns {@code null} when no
+	 * extraction result is wired, so the caller can fall back to the plain test
+	 * response logic.
+	 */
+	private String produceExtractionJsonResponse(Prompt prompt) {
+		if (configuration == null) {
+			return null;
+		}
+		Object canned = configuration.getResponseObjects().get(LLMExtractionResult.class);
+		if (!(canned instanceof LLMExtractionResult) && configuration.getResponseCallbacks()
+				.containsKey(LLMExtractionResult.class)) {
+			KnowledgeExtractionCallEvent event = new KnowledgeExtractionCallEvent(prompt, prompt.getInstructions(),
+					List.of());
+			canned = configuration.getResponseCallbacks().get(LLMExtractionResult.class).apply(event);
+		}
+		if (canned instanceof LLMExtractionResult result) {
+			try {
+				return JSON.writeValueAsString(result);
+			} catch (JacksonException e) {
+				LOGGER.error("Failed to serialize canned LLMExtractionResult to JSON", e);
+				return "";
+			}
+		}
+		return null;
 	}
 	
 	/**


### PR DESCRIPTION
## Problem

After the Spring Boot 4.1 + Spring AI 2.0 port (`b2c70bf85`), the graphrag JSON extraction path in `GraphDataExtractionServiceImpl.extract(...)` started going through Spring AI's real structured-output code:

```
DefaultChatClient$DefaultCallResponseSpec.entity(Class)
  -> BeanOutputConverter<LLMExtractionResult>
  -> ObjectMapper.readValue(...)
```

The fake `TestKnowledgeExtractionChatModel.call(Prompt)` still returned the echoed prompt text (`testResponseLogic = (s)->s`), so `BeanOutputConverter` threw:

```
tools.jackson.core.exc.StreamReadException: Unrecognized token 'This'
  at org.springframework.ai.converter.BeanOutputConverter.convert(BeanOutputConverter.java:194)
  at org.springframework.ai.chat.client.DefaultChatClient$DefaultCallResponseSpec.doSingleWithBeanOutputConverter(DefaultChatClient.java:616)
  at ai.gebo.architecture.graphrag.extraction.services.impl.GraphDataExtractionServiceImpl.extract(GraphDataExtractionServiceImpl.java:540)
```

The errors were caught per-worker in `GraphextractionProcessorBatchReceiver.java:133-140` and the existing test assertions only check vectorization + workflow-finished, so the suite stayed green while the GRAPHEXTRACTION step silently reported `hasErrors:true / processed:0` and nothing reached Neo4j.

## Root cause

The fake-LLM layer was not adapted to the Spring AI 2.0 structured-output contract: it returned plain text where `BeanOutputConverter` demanded JSON. The existing `responseObjects` / `responseCallbacks` wiring on `TestKnowledgeExtractionModelConfiguration` was only consulted by the bypassed `TestKnowledgeExtractionCallResponseSpecWrapper.entity(Class)` (it sits behind `getChatClient()`, which `doWithChatClient` never calls).

## Fix

Only the fake-LLM layer is touched — no change to `GraphDataExtractionServiceImpl`, the abstraction layer, or any test setup.

`TestKnowledgeExtractionChatModel.call(Prompt)` now first resolves a canned `LLMExtractionResult` from `configuration.responseObjects` (or, falling back, from `configuration.responseCallbacks` fed with a `KnowledgeExtractionCallEvent` built from `prompt.getInstructions()`) and serializes it to JSON via Jackson. The real Spring AI 2.0 path then parses that JSON successfully. When no canned extraction result is wired, the old `testResponseLogic` behavior is preserved.

`gebo.llms.tests.services/pom.xml` adds `gebo.architecture.graphrag.extraction` as a dependency so the fake model can reference `LLMExtractionResult`.

## Verification

`mvn clean package -P under-development` → **BUILD SUCCESS**, 42 tests, 0 failures, 0 errors, 0 skipped.

GRAPHEXTRACTION step status across the integration suite is now `hasErrors:false` with real processed counts and segment/token tallies (entities/events/relations persisted to Neo4j). Before vs. after for `SharedFilesystemIntegrationTest#testSharedFilesystemProcessing`:

Before:
```
stepId:GRAPHEXTRACTION completed:true hasErrors:true  input:6 discarded:2 processed:0 errors:4 sentToNextStep:0 segments:0   tokens:0
```

After:
```
stepId:GRAPHEXTRACTION completed:true hasErrors:false input:6 discarded:2 processed:4 errors:0 sentToNextStep:0 segments:359 tokens:115106
```

## Files changed

- `gebo.llms.parent/gebo.llms.tests.services/pom.xml` — add `gebo.architecture.graphrag.extraction` dependency.
- `gebo.llms.parent/gebo.llms.tests.services/.../TestKnowledgeExtractionChatModel.java` — `call(Prompt)` returns serialized `LLMExtractionResult` JSON when a canned result is wired.