### PR TITLE
Helm chart: install the microservices on Kubernetes (optional/mandatory toggles)

### DIFF
--- a/deploy/helm/gebo-microservices/Chart.yaml
+++ b/deploy/helm/gebo-microservices/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: gebo-microservices
+description: >-
+  Gebo.ai microservices platform — the Eureka registry, the API gateway edge, and
+  every backend microservice, with per-service optional/mandatory install toggles
+  and a topology ConfigMap kept in sync with the deployed footprint. Optionally
+  deploys the stateful dependencies (MongoDB, RabbitMQ, Qdrant, Neo4j, OpenSearch)
+  in-cluster, or points them at external/managed instances.
+type: application
+version: 0.1.0
+# appVersion mirrors the default image tag in values.yaml (image.tag).
+appVersion: "1.0.2.0-SNAPSHOT"
+keywords:
+  - gebo
+  - rag
+  - microservices
+home: https://gebo.ai

--- a/deploy/helm/gebo-microservices/README.md
+++ b/deploy/helm/gebo-microservices/README.md
@@ -1,0 +1,99 @@
+# gebo-microservices Helm chart
+
+Deploys the Gebo.ai microservices platform to Kubernetes: the Eureka registry, the
+API gateway edge, and every backend microservice — with per-service **optional /
+mandatory** install toggles, and a **messaging-topology ConfigMap kept in sync with
+the deployed footprint**. Stateful dependencies (MongoDB, RabbitMQ, Qdrant, Neo4j,
+OpenSearch) are deployed in-cluster by default, or pointed at external/managed
+instances.
+
+Mirrors `dockers/gebo.microservices/docker-compose.yml` + its `config/application.yml`.
+
+## Prerequisites
+
+- A Kubernetes cluster + `helm` 3.x.
+- The `geboai/*.gebo.ai:<tag>` images **pushed to a registry the cluster can pull**
+  (the Maven `-P docker` build produces them locally as `jib:buildTar`; for a cluster
+  use `jib:build` to a registry, then set `image.registry` / `imagePullSecrets`).
+
+## Install
+
+```bash
+helm install gebo deploy/helm/gebo-microservices \
+  --namespace gebo --create-namespace \
+  --set image.registry=myregistry.example.com/ \
+  --set image.tag=1.0.2.0-SNAPSHOT
+```
+
+## Optional / mandatory services
+
+`backends.<svc>.enabled` toggles optional services. **Mandatory** services
+(`heimdall`, `brain`, `tyr`, `chunker`, `vectorizator`, plus `eureka` and `gateway`)
+are always rendered; setting `enabled: false` on one **fails the install** by design.
+
+```yaml
+backends:
+  graphicator: { enabled: false }   # drop graphrag (no neo4j needed)
+  fulltextor:  { enabled: false }   # drop full-text (no opensearch needed)
+  jira:        { enabled: false }   # don't install the Jira connector
+```
+
+Whatever you enable is **also** what gets declared in
+`gebo.microservices.topology` (rendered with `include-defaults: false`), so the
+declared topology never drifts from what is deployed — which is what the tyr
+topology coordinator and the workflow-step enablement rely on. If you disable a
+connector, its content-handler is simply not installed and not declared; disable
+`graphicator`/`fulltextor` and the corresponding workflow step (GRAPHEXTRACTION /
+FULLTEXT_INDEXING) is off cluster-wide.
+
+> The topology `services:` map in `templates/configmap-shared.yaml` mirrors
+> `GeboStandardMicroservices.DEFAULTS`. If that Java source gains/renames modules,
+> update the ConfigMap to match.
+
+## Stateful dependencies
+
+In-cluster by default; flip any to external:
+
+```yaml
+infra:
+  mongodb:
+    enabled: false
+    external: { connectionString: "mongodb://user:pass@mongo.prod:27017/?authSource=admin" }
+  opensearch:
+    enabled: false
+    external: { protocol: https, host: opensearch.prod, port: 9200, username: admin }
+```
+
+The in-cluster StatefulSets are **dev-grade** (single replica). For production prefer
+managed services or dedicated operators.
+
+## Secrets
+
+Dev defaults ship under `secrets:` — **override them**, or bring your own with
+`secrets.existingSecret: my-secret` (which must expose the same keys:
+`GEBO_TOKEN_SECRET`, `MONGO_USERNAME`, `MONGO_PASSWORD`, `RABBITMQ_PASSWORD`,
+`QDRANT_API_KEY`, `NEO4J_PASSWORD`, `OPENSEARCH_PASSWORD`, `OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`). They are consumed as env vars and referenced from the shared
+`application.yml` as `${...}` placeholders.
+
+## Discovery
+
+Keeps **Eureka** + client-side load balancing (topology `url.strategy: LOAD_BALANCER`),
+matching the compose deployment — no application changes. Instances register by pod
+IP (`eureka.instance.prefer-ip-address=true`) so cross-pod discovery works in-cluster.
+
+## Not yet included
+
+- The observability stack (otel-collector / Prometheus / Tempo / Grafana) — point
+  `common.otlpTracingEndpoint` at your own collector, or add it later.
+- Production hardening of the stateful StatefulSets (HA, backups, node tuning such as
+  `vm.max_map_count` for OpenSearch).
+
+## Validate before applying
+
+This chart has not been rendered against a live cluster. Before use:
+
+```bash
+helm lint deploy/helm/gebo-microservices
+helm template gebo deploy/helm/gebo-microservices | kubectl apply --dry-run=client -f -
+```

--- a/deploy/helm/gebo-microservices/README.md
+++ b/deploy/helm/gebo-microservices/README.md
@@ -82,10 +82,29 @@ Keeps **Eureka** + client-side load balancing (topology `url.strategy: LOAD_BALA
 matching the compose deployment — no application changes. Instances register by pod
 IP (`eureka.instance.prefer-ip-address=true`) so cross-pod discovery works in-cluster.
 
+## Observability (optional)
+
+Off by default. Enable the in-cluster stack (otel-collector → Tempo for traces,
+Prometheus for metrics, Grafana with both datasources + a starter dashboard):
+
+```yaml
+observability:
+  enabled: true
+  grafana:
+    service: { type: LoadBalancer }   # or port-forward to reach the UI
+```
+
+When enabled, backends export traces to the in-cluster collector (overrides
+`common.otlpTracingEndpoint`), and Prometheus scrapes exactly the enabled backends'
+`/<svc>/actuator/prometheus`. To use your own collector instead, leave
+`observability.enabled: false` and set `common.otlpTracingEndpoint`.
+
+> Actuator endpoints sit behind auth in these images, so Prometheus scrapes may need
+> the management endpoints opened up (or a scrape credential) to return data — the
+> config mirrors the compose setup as-is.
+
 ## Not yet included
 
-- The observability stack (otel-collector / Prometheus / Tempo / Grafana) — point
-  `common.otlpTracingEndpoint` at your own collector, or add it later.
 - Production hardening of the stateful StatefulSets (HA, backups, node tuning such as
   `vm.max_map_count` for OpenSearch).
 

--- a/deploy/helm/gebo-microservices/files/gebo-overview.json
+++ b/deploy/helm/gebo-microservices/files/gebo-overview.json
@@ -1,0 +1,88 @@
+{
+  "title": "Gebo.ai Overview",
+  "uid": "gebo-overview",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Services up",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "up",
+          "legendFormat": "{{job}} - {{service}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "HTTP request rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count[1m])) by (service, uri)",
+          "legendFormat": "{{service}} {{uri}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP average request duration",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_sum[1m])) by (service) / sum(rate(http_server_requests_seconds_count[1m])) by (service)",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Message broker routing rate (per hop)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(rate(gebo_messaging_broker_routing_seconds_count[1m])) by (sourceModule, targetModule)",
+          "legendFormat": "{{sourceModule}} -> {{targetModule}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "JVM memory used",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "gebo-prometheus" },
+          "expr": "sum(jvm_memory_used_bytes) by (service, area)",
+          "legendFormat": "{{service}} {{area}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/helm/gebo-microservices/templates/NOTES.txt
+++ b/deploy/helm/gebo-microservices/templates/NOTES.txt
@@ -1,0 +1,31 @@
+Gebo.ai microservices installed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Mandatory services (always installed):
+{{- range $name, $svc := .Values.backends }}{{ if $svc.mandatory }}
+  - {{ $name }}{{ end }}{{ end }}
+  - eureka (registry)
+  - gateway (edge)
+
+Optional services enabled in THIS install:
+{{- range $name, $svc := .Values.backends }}{{ if and (not $svc.mandatory) (include "gebo.backendEnabled" $svc) }}
+  - {{ $name }}{{ end }}{{ end }}
+
+The declared messaging topology (gebo.microservices.topology) was rendered to match
+exactly the services above, so the tyr coordinator and the workflow-step enablement
+see the real footprint.
+
+Reach the gateway (the edge / Angular UI + aggregated API):
+{{- if .Values.gateway.ingress.enabled }}
+  http{{ if .Values.gateway.ingress.tls.enabled }}s{{ end }}://{{ .Values.gateway.ingress.host }}/
+{{- else if eq .Values.gateway.service.type "LoadBalancer" }}
+  kubectl -n {{ .Release.Namespace }} get svc {{ .Release.Name }}-gateway   # external IP
+{{- else }}
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ .Release.Name }}-gateway {{ .Values.gateway.port }}:{{ .Values.gateway.port }}
+  then open http://localhost:{{ .Values.gateway.port }}/
+{{- end }}
+
+Watch rollout:
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/part-of=gebo-microservices -w
+
+{{ if not .Values.secrets.existingSecret }}WARNING: this release uses the chart's DEV-DEFAULT secrets. Override values under
+`secrets:` (or set `secrets.existingSecret`) before any non-dev use.{{ end }}

--- a/deploy/helm/gebo-microservices/templates/NOTES.txt
+++ b/deploy/helm/gebo-microservices/templates/NOTES.txt
@@ -26,6 +26,15 @@ Reach the gateway (the edge / Angular UI + aggregated API):
 
 Watch rollout:
   kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/part-of=gebo-microservices -w
+{{- if .Values.observability.enabled }}
+
+Observability is ON (otel-collector -> Tempo, Prometheus, Grafana). Reach Grafana:
+{{- if eq .Values.observability.grafana.service.type "LoadBalancer" }}
+  kubectl -n {{ .Release.Namespace }} get svc {{ .Release.Name }}-grafana   # external IP
+{{- else }}
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ .Release.Name }}-grafana 3000:3000
+{{- end }}
+{{- end }}
 
 {{ if not .Values.secrets.existingSecret }}WARNING: this release uses the chart's DEV-DEFAULT secrets. Override values under
 `secrets:` (or set `secrets.existingSecret`) before any non-dev use.{{ end }}

--- a/deploy/helm/gebo-microservices/templates/_helpers.tpl
+++ b/deploy/helm/gebo-microservices/templates/_helpers.tpl
@@ -74,11 +74,15 @@ true
   value: {{ .Values.common.javaToolOptions | quote }}
 - name: MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE
   value: {{ .Values.common.managementExposure | quote }}
-{{- if .Values.common.otlpTracingEndpoint }}
+{{- $otlp := .Values.common.otlpTracingEndpoint -}}
+{{- if .Values.observability.enabled -}}
+{{- $otlp = printf "http://%s-otel-collector:4318/v1/traces" .Release.Name -}}
+{{- end }}
+{{- if $otlp }}
 - name: MANAGEMENT_TRACING_SAMPLING_PROBABILITY
   value: {{ .Values.common.tracingSamplingProbability | quote }}
 - name: MANAGEMENT_OTLP_TRACING_ENDPOINT
-  value: {{ .Values.common.otlpTracingEndpoint | quote }}
+  value: {{ $otlp | quote }}
 {{- end }}
 {{- with .Values.common.extraEnv }}
 {{ toYaml . }}

--- a/deploy/helm/gebo-microservices/templates/_helpers.tpl
+++ b/deploy/helm/gebo-microservices/templates/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/* Chart name / fullname */}}
+{{- define "gebo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "gebo.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "gebo.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Common labels */}}
+{{- define "gebo.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: gebo-microservices
+{{- end -}}
+
+{{/*
+  Image reference for a backend/edge service.
+  Usage: {{ include "gebo.image" (dict "root" $ "svc" "brain") }}
+  -> {{ registry }}{{ namespace }}/brain.gebo.ai:{{ tag }}
+*/}}
+{{- define "gebo.image" -}}
+{{- $img := .root.Values.image -}}
+{{- printf "%s%s/%s.gebo.ai:%s" $img.registry $img.namespace .svc $img.tag -}}
+{{- end -}}
+
+{{/*
+  Topology microservice-id for a service short name: "aws-s3" -> "aws_s3_gebo_ai".
+  Usage: {{ include "gebo.microserviceId" "aws-s3" }}
+*/}}
+{{- define "gebo.microserviceId" -}}
+{{- printf "%s_gebo_ai" (. | replace "-" "_") -}}
+{{- end -}}
+
+{{/*
+  Whether a backend is deployed: mandatory ones always; optional ones unless enabled:false.
+  Usage: {{ if (include "gebo.backendEnabled" $svc) }}  ($svc is the per-service values dict)
+  Returns "true" or "" (empty is falsy).
+*/}}
+{{- define "gebo.backendEnabled" -}}
+{{- if .mandatory -}}
+true
+{{- else if ne (.enabled | toString) "false" -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Fail the install if a mandatory backend was explicitly disabled.
+  Usage: {{ include "gebo.assertMandatory" (dict "name" $name "svc" $svc) }}
+*/}}
+{{- define "gebo.assertMandatory" -}}
+{{- if and .svc.mandatory (eq (.svc.enabled | toString) "false") -}}
+{{- fail (printf "backends.%s is mandatory and cannot be disabled (enabled:false)" .name) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Common backend env block (mirrors compose x-microservice + secret envs).
+  Usage: {{ include "gebo.backendEnv" $ | nindent 12 }}
+*/}}
+{{- define "gebo.backendEnv" -}}
+- name: EUREKA_CLIENT_SERVICEURL_DEFAULTZONE
+  value: "http://{{ .Release.Name }}-eureka:{{ .Values.eureka.port }}/eureka/"
+- name: EUREKA_INSTANCE_PREFERIPADDRESS
+  value: "true"
+- name: SPRING_CONFIG_ADDITIONAL_LOCATION
+  value: "file:/opt/gebo.ai/config/"
+- name: JAVA_TOOL_OPTIONS
+  value: {{ .Values.common.javaToolOptions | quote }}
+- name: MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE
+  value: {{ .Values.common.managementExposure | quote }}
+{{- if .Values.common.otlpTracingEndpoint }}
+- name: MANAGEMENT_TRACING_SAMPLING_PROBABILITY
+  value: {{ .Values.common.tracingSamplingProbability | quote }}
+- name: MANAGEMENT_OTLP_TRACING_ENDPOINT
+  value: {{ .Values.common.otlpTracingEndpoint | quote }}
+{{- end }}
+{{- with .Values.common.extraEnv }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/* Name of the Secret backends read via envFrom. */}}
+{{- define "gebo.secretName" -}}
+{{- .Values.secrets.existingSecret | default (printf "%s-secrets" .Release.Name) -}}
+{{- end -}}

--- a/deploy/helm/gebo-microservices/templates/backends.yaml
+++ b/deploy/helm/gebo-microservices/templates/backends.yaml
@@ -1,0 +1,104 @@
+{{- /* One Deployment + Service per enabled backend. Mandatory ones always; optional ones gated. */ -}}
+{{- $root := . -}}
+{{- range $name, $svc := .Values.backends }}
+{{- include "gebo.assertMandatory" (dict "name" $name "svc" $svc) -}}
+{{- if include "gebo.backendEnabled" $svc }}
+{{- $port := $svc.port -}}
+{{- $resources := $svc.resources | default $root.Values.resources -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $root.Release.Name }}-{{ $name }}
+  labels:
+    {{- include "gebo.labels" $root | nindent 4 }}
+    app.kubernetes.io/name: {{ $name }}
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    gebo.ai/microservice-id: {{ include "gebo.microserviceId" $name }}
+    gebo.ai/mandatory: {{ $svc.mandatory | default false | quote }}
+spec:
+  replicas: {{ $svc.replicas | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $name }}
+      app.kubernetes.io/instance: {{ $root.Release.Name }}
+  template:
+    metadata:
+      labels:
+        {{- include "gebo.labels" $root | nindent 8 }}
+        app.kubernetes.io/name: {{ $name }}
+        app.kubernetes.io/instance: {{ $root.Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $root.Template.BasePath "/configmap-shared.yaml") $root | sha256sum }}
+    spec:
+      {{- with $root.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ $name }}
+          image: {{ include "gebo.image" (dict "root" $root "svc" $name) }}
+          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $port }}
+          env:
+            {{- include "gebo.backendEnv" $root | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: {{ include "gebo.secretName" $root }}
+          # tcpSocket (port-open) rather than httpGet: the actuator health endpoint
+          # sits behind the service's context-path AND requires auth, so an
+          # unauthenticated HTTP probe can't pass. The port only binds once the app
+          # has fully started, so this is a sound readiness signal for these images.
+          startupProbe:
+            tcpSocket:
+              port: {{ $port }}
+            failureThreshold: 60
+            periodSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: {{ $port }}
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: {{ $port }}
+            periodSeconds: 20
+            failureThreshold: 6
+          resources:
+            {{- toYaml $resources | nindent 12 }}
+          volumeMounts:
+            - name: shared-config
+              mountPath: /opt/gebo.ai/config
+              readOnly: true
+            - name: gebo-home
+              mountPath: /opt/gebo.ai/home
+            - name: gebo-work
+              mountPath: /opt/gebo.ai/work
+      volumes:
+        - name: shared-config
+          configMap:
+            name: {{ $root.Release.Name }}-shared-config
+        - name: gebo-home
+          emptyDir: {}
+        - name: gebo-work
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $root.Release.Name }}-{{ $name }}
+  labels:
+    {{- include "gebo.labels" $root | nindent 4 }}
+    app.kubernetes.io/name: {{ $name }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ $name }}
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+  ports:
+    - name: http
+      port: {{ $port }}
+      targetPort: {{ $port }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/gebo-microservices/templates/configmap-shared.yaml
+++ b/deploy/helm/gebo-microservices/templates/configmap-shared.yaml
@@ -1,0 +1,131 @@
+{{- /*
+  Shared config mounted read-only at /opt/gebo.ai/config in every backend
+  (SPRING_CONFIG_ADDITIONAL_LOCATION), on top of each service's baked application.yml.
+  Mirrors dockers/gebo.microservices/config/application.yml, with:
+    - infra hosts pointing at in-cluster Services (or external.* when disabled),
+    - secrets as ${...} placeholders resolved from the Secret (envFrom),
+    - a topology that keeps include-defaults:true and removes exactly the backends
+      NOT deployed here via disabled-services, so declared == deployed. Module maps
+      come from GeboStandardMicroservices.DEFAULTS (no duplication in the chart).
+*/ -}}
+{{- $rel := .Release.Name -}}
+{{- $disabled := list -}}
+{{- range $n, $s := .Values.backends }}{{- if not (include "gebo.backendEnabled" $s) }}{{- $disabled = append $disabled (include "gebo.microserviceId" $n) }}{{- end }}{{- end -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-shared-config
+  labels:
+    {{- include "gebo.labels" . | nindent 4 }}
+data:
+  application.yml: |
+    logging:
+      level:
+        root: INFO
+    server:
+      compression:
+        enabled: true
+    spring:
+      servlet:
+        multipart:
+          enabled: true
+          max-file-size: 100MB
+          max-request-size: 100MB
+      rabbitmq:
+        host: {{ if .Values.infra.rabbitmq.enabled }}{{ $rel }}-rabbitmq{{ else }}{{ .Values.infra.rabbitmq.external.host }}{{ end }}
+        port: {{ if .Values.infra.rabbitmq.enabled }}5672{{ else }}{{ .Values.infra.rabbitmq.external.port }}{{ end }}
+        username: {{ .Values.infra.rabbitmq.username }}
+        password: ${RABBITMQ_PASSWORD}
+      neo4j:
+        uri: {{ if .Values.infra.neo4j.enabled }}bolt://{{ $rel }}-neo4j:7687{{ else }}{{ .Values.infra.neo4j.external.uri }}{{ end }}
+        authentication:
+          username: {{ .Values.infra.neo4j.username }}
+          password: ${NEO4J_PASSWORD}
+      jackson:
+        date-format: yyyy-MM-dd HH:mm:ss
+        serialization:
+          INDENT_OUTPUT: true
+
+    security.provider.1: org.bouncycastle.jce.provider.BouncyCastleProvider
+
+    ai.gebo.security:
+      auth:
+        tokenSecret: ${GEBO_TOKEN_SECRET}
+        tokenExpirationMsec: 120000
+      cors:
+        allowedOrigins: {{ .Values.security.corsAllowedOrigins | quote }}
+    ai.gebo.security.system-user:
+      username: heimdall@bifrost.gebo.ai
+      roles: [SYSTEM, ADMIN]
+      token-expiration-msec: 300000
+
+    ai.gebo.config:
+      setupConfiguresWorkdir: false
+      security: true
+      setup: true
+      customKeyStore: false
+      enableCommunityModules: true
+
+    ai.gebo.mongodb:
+      enabled: true
+      connectionString: {{ if .Values.infra.mongodb.enabled }}mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@{{ $rel }}-mongodb:27017/?authSource=admin{{ else }}{{ .Values.infra.mongodb.external.connectionString }}{{ end }}
+
+    ai.gebo.vectorstore:
+      use: QDRANT
+      qdrant:
+        host: {{ if .Values.infra.qdrant.enabled }}{{ $rel }}-qdrant{{ else }}{{ .Values.infra.qdrant.external.host }}{{ end }}
+        port: {{ if .Values.infra.qdrant.enabled }}6334{{ else }}{{ .Values.infra.qdrant.external.port }}{{ end }}
+        tls: {{ if .Values.infra.qdrant.enabled }}false{{ else }}{{ .Values.infra.qdrant.external.tls }}{{ end }}
+        apiKey: ${QDRANT_API_KEY}
+
+    ai.gebo.opensearch:
+      enabled: true
+      protocol: {{ if .Values.infra.opensearch.enabled }}https{{ else }}{{ .Values.infra.opensearch.external.protocol }}{{ end }}
+      host: {{ if .Values.infra.opensearch.enabled }}{{ $rel }}-opensearch{{ else }}{{ .Values.infra.opensearch.external.host }}{{ end }}
+      port: {{ if .Values.infra.opensearch.enabled }}9200{{ else }}{{ .Values.infra.opensearch.external.port }}{{ end }}
+      username: {{ if .Values.infra.opensearch.enabled }}admin{{ else }}{{ .Values.infra.opensearch.external.username }}{{ end }}
+      password: ${OPENSEARCH_PASSWORD}
+
+    ai.gebo.llms.config:
+      openAIEnabled: {{ .Values.llm.openAIEnabled }}
+      anthropicEnabled: {{ .Values.llm.anthropicEnabled }}
+      ollamaEnabled: {{ .Values.llm.ollamaEnabled }}
+    spring.ai:
+      openai:
+        api-key: ${OPENAI_API_KEY}
+        embedding:
+          enabled: true
+          options:
+            model: {{ .Values.llm.openaiEmbeddingModel }}
+        chat:
+          api-key: ${OPENAI_API_KEY}
+          options:
+            model: {{ .Values.llm.openaiChatModel }}
+      anthropic:
+        api-key: ${ANTHROPIC_API_KEY}
+
+    ai.gebo.security.client:
+      cache-ttl: 60s
+      cache-max-entries: 10000
+    ai.gebo.acl.client:
+      cache-ttl: 60s
+      cache-max-entries: 10000
+    ai.gebo.secrets.client:
+      cache-ttl: 60s
+      cache-max-entries: 2000
+
+    reactor.schedulers.defaultPoolSize: 16
+
+    # --- Declared messaging topology: DEFAULTS minus what is not deployed here ---
+    # include-defaults keeps the authoritative module maps from
+    # GeboStandardMicroservices; disabled-services removes exactly the backends
+    # turned off in this install, so declared == deployed (mandatory ones are never
+    # in the list). Avoids re-specifying module maps in the chart.
+    gebo.microservices.topology:
+      url:
+        strategy: LOAD_BALANCER
+      include-defaults: true
+      disabled-services: {{ $disabled | toJson }}
+{{- with .Values.extraSharedConfig }}
+    {{- . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/gebo-microservices/templates/edge.yaml
+++ b/deploy/helm/gebo-microservices/templates/edge.yaml
@@ -1,0 +1,142 @@
+{{- /* Eureka registry + API gateway edge (+ optional Ingress). */ -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-eureka
+  labels:
+    {{- include "gebo.labels" . | nindent 4 }}
+    app.kubernetes.io/name: eureka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eureka
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        {{- include "gebo.labels" . | nindent 8 }}
+        app.kubernetes.io/name: eureka
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: eureka
+          image: {{ include "gebo.image" (dict "root" . "svc" "eureka") }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.eureka.port }}
+          resources:
+            {{- toYaml .Values.eureka.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-eureka
+  labels:
+    {{- include "gebo.labels" . | nindent 4 }}
+    app.kubernetes.io/name: eureka
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: eureka
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.eureka.port }}
+      targetPort: {{ .Values.eureka.port }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-gateway
+  labels:
+    {{- include "gebo.labels" . | nindent 4 }}
+    app.kubernetes.io/name: gateway
+spec:
+  replicas: {{ .Values.gateway.replicas | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gateway
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        {{- include "gebo.labels" . | nindent 8 }}
+        app.kubernetes.io/name: gateway
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: gateway
+          image: {{ include "gebo.image" (dict "root" . "svc" "gateway") }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.gateway.port }}
+          env:
+            - name: EUREKA_CLIENT_SERVICEURL_DEFAULTZONE
+              value: "http://{{ .Release.Name }}-eureka:{{ .Values.eureka.port }}/eureka/"
+            - name: EUREKA_INSTANCE_PREFERIPADDRESS
+              value: "true"
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-gateway
+  labels:
+    {{- include "gebo.labels" . | nindent 4 }}
+    app.kubernetes.io/name: gateway
+spec:
+  type: {{ .Values.gateway.service.type }}
+  selector:
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.gateway.port }}
+      targetPort: {{ .Values.gateway.port }}
+{{- if .Values.gateway.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-gateway
+  labels:
+    {{- include "gebo.labels" . | nindent 4 }}
+  {{- with .Values.gateway.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.gateway.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.gateway.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.gateway.ingress.host | quote }}
+      secretName: {{ .Values.gateway.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.gateway.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-gateway
+                port:
+                  number: {{ .Values.gateway.port }}
+{{- end }}

--- a/deploy/helm/gebo-microservices/templates/infra.yaml
+++ b/deploy/helm/gebo-microservices/templates/infra.yaml
@@ -1,0 +1,236 @@
+{{- /*
+  In-cluster stateful dependencies. Each is gated by infra.<dep>.enabled; when
+  disabled, nothing is rendered and the app points at infra.<dep>.external.* .
+  Dev-grade single-replica StatefulSets mirroring docker-compose. For production,
+  prefer managed services / dedicated operators (set enabled:false + external.*).
+*/ -}}
+{{- $rel := .Release.Name -}}
+{{- $secret := include "gebo.secretName" . -}}
+
+{{- if .Values.infra.mongodb.enabled }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $rel }}-mongodb
+  labels: { app.kubernetes.io/name: mongodb }
+spec:
+  serviceName: {{ $rel }}-mongodb
+  replicas: 1
+  selector: { matchLabels: { app.kubernetes.io/name: mongodb, app.kubernetes.io/instance: {{ $rel }} } }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: mongodb, app.kubernetes.io/instance: {{ $rel }} }
+    spec:
+      containers:
+        - name: mongodb
+          image: {{ .Values.infra.mongodb.image }}
+          args: ["mongod", "--wiredTigerCacheSizeGB=1"]
+          ports: [{ name: mongo, containerPort: 27017 }]
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom: { secretKeyRef: { name: {{ $secret }}, key: MONGO_USERNAME } }
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ $secret }}, key: MONGO_PASSWORD } }
+          volumeMounts: [{ name: data, mountPath: /data/db }]
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- with .Values.infra.mongodb.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources: { requests: { storage: {{ .Values.infra.mongodb.storage }} } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $rel }}-mongodb
+  labels: { app.kubernetes.io/name: mongodb }
+spec:
+  selector: { app.kubernetes.io/name: mongodb, app.kubernetes.io/instance: {{ $rel }} }
+  ports: [{ name: mongo, port: 27017, targetPort: 27017 }]
+{{- end }}
+
+{{- if .Values.infra.rabbitmq.enabled }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $rel }}-rabbitmq
+  labels: { app.kubernetes.io/name: rabbitmq }
+spec:
+  serviceName: {{ $rel }}-rabbitmq
+  replicas: 1
+  selector: { matchLabels: { app.kubernetes.io/name: rabbitmq, app.kubernetes.io/instance: {{ $rel }} } }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: rabbitmq, app.kubernetes.io/instance: {{ $rel }} }
+    spec:
+      containers:
+        - name: rabbitmq
+          image: {{ .Values.infra.rabbitmq.image }}
+          ports:
+            - { name: amqp, containerPort: 5672 }
+            - { name: management, containerPort: 15672 }
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              value: {{ .Values.infra.rabbitmq.username | quote }}
+            - name: RABBITMQ_DEFAULT_PASS
+              valueFrom: { secretKeyRef: { name: {{ $secret }}, key: RABBITMQ_PASSWORD } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $rel }}-rabbitmq
+  labels: { app.kubernetes.io/name: rabbitmq }
+spec:
+  selector: { app.kubernetes.io/name: rabbitmq, app.kubernetes.io/instance: {{ $rel }} }
+  ports:
+    - { name: amqp, port: 5672, targetPort: 5672 }
+    - { name: management, port: 15672, targetPort: 15672 }
+{{- end }}
+
+{{- if .Values.infra.qdrant.enabled }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $rel }}-qdrant
+  labels: { app.kubernetes.io/name: qdrant }
+spec:
+  serviceName: {{ $rel }}-qdrant
+  replicas: 1
+  selector: { matchLabels: { app.kubernetes.io/name: qdrant, app.kubernetes.io/instance: {{ $rel }} } }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: qdrant, app.kubernetes.io/instance: {{ $rel }} }
+    spec:
+      containers:
+        - name: qdrant
+          image: {{ .Values.infra.qdrant.image }}
+          ports:
+            - { name: http, containerPort: 6333 }
+            - { name: grpc, containerPort: 6334 }
+          env:
+            - name: QDRANT__SERVICE__API_KEY
+              valueFrom: { secretKeyRef: { name: {{ $secret }}, key: QDRANT_API_KEY } }
+            - name: QDRANT__STORAGE__OPTIMIZE_INDEXING
+              value: "true"
+          volumeMounts: [{ name: data, mountPath: /qdrant/storage }]
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- with .Values.infra.qdrant.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources: { requests: { storage: {{ .Values.infra.qdrant.storage }} } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $rel }}-qdrant
+  labels: { app.kubernetes.io/name: qdrant }
+spec:
+  selector: { app.kubernetes.io/name: qdrant, app.kubernetes.io/instance: {{ $rel }} }
+  ports:
+    - { name: http, port: 6333, targetPort: 6333 }
+    - { name: grpc, port: 6334, targetPort: 6334 }
+{{- end }}
+
+{{- if .Values.infra.neo4j.enabled }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $rel }}-neo4j
+  labels: { app.kubernetes.io/name: neo4j }
+spec:
+  serviceName: {{ $rel }}-neo4j
+  replicas: 1
+  selector: { matchLabels: { app.kubernetes.io/name: neo4j, app.kubernetes.io/instance: {{ $rel }} } }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: neo4j, app.kubernetes.io/instance: {{ $rel }} }
+    spec:
+      containers:
+        - name: neo4j
+          image: {{ .Values.infra.neo4j.image }}
+          ports:
+            - { name: bolt, containerPort: 7687 }
+            - { name: http, containerPort: 7474 }
+          env:
+            - name: NEO4J_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ $secret }}, key: NEO4J_PASSWORD } }
+            - name: NEO4J_AUTH
+              value: "{{ .Values.infra.neo4j.username }}/$(NEO4J_PASSWORD)"
+            - name: NEO4JLABS_PLUGINS
+              value: '["apoc"]'
+          volumeMounts: [{ name: data, mountPath: /data }]
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- with .Values.infra.neo4j.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources: { requests: { storage: {{ .Values.infra.neo4j.storage }} } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $rel }}-neo4j
+  labels: { app.kubernetes.io/name: neo4j }
+spec:
+  selector: { app.kubernetes.io/name: neo4j, app.kubernetes.io/instance: {{ $rel }} }
+  ports:
+    - { name: bolt, port: 7687, targetPort: 7687 }
+    - { name: http, port: 7474, targetPort: 7474 }
+{{- end }}
+
+{{- if .Values.infra.opensearch.enabled }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $rel }}-opensearch
+  labels: { app.kubernetes.io/name: opensearch }
+spec:
+  serviceName: {{ $rel }}-opensearch
+  replicas: 1
+  selector: { matchLabels: { app.kubernetes.io/name: opensearch, app.kubernetes.io/instance: {{ $rel }} } }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: opensearch, app.kubernetes.io/instance: {{ $rel }} }
+    spec:
+      containers:
+        - name: opensearch
+          image: {{ .Values.infra.opensearch.image }}
+          ports: [{ name: http, containerPort: 9200 }]
+          env:
+            - { name: discovery.type, value: single-node }
+            - { name: plugins.security.ssl.http.enabled, value: "true" }
+            - { name: bootstrap.memory_lock, value: "true" }
+            - { name: OPENSEARCH_JAVA_OPTS, value: {{ .Values.infra.opensearch.javaOpts | quote }} }
+            - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ $secret }}, key: OPENSEARCH_PASSWORD } }
+          volumeMounts: [{ name: data, mountPath: /usr/share/opensearch/data }]
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- with .Values.infra.opensearch.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources: { requests: { storage: {{ .Values.infra.opensearch.storage }} } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $rel }}-opensearch
+  labels: { app.kubernetes.io/name: opensearch }
+spec:
+  selector: { app.kubernetes.io/name: opensearch, app.kubernetes.io/instance: {{ $rel }} }
+  ports: [{ name: http, port: 9200, targetPort: 9200 }]
+{{- end }}

--- a/deploy/helm/gebo-microservices/templates/observability.yaml
+++ b/deploy/helm/gebo-microservices/templates/observability.yaml
@@ -1,0 +1,310 @@
+{{- /*
+  Observability stack: otel-collector -> Tempo (traces), Prometheus (metrics),
+  Grafana (both datasources + starter dashboard). Gated by observability.enabled.
+  Mirrors dockers/gebo.microservices/{otel-collector-config,tempo-config,prometheus}.yaml.
+*/ -}}
+{{- if .Values.observability.enabled }}
+{{- $rel := .Release.Name -}}
+{{- $o := .Values.observability -}}
+# ---------------- otel-collector ----------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $rel }}-otel-collector
+  labels: { app.kubernetes.io/name: otel-collector }
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          http: { endpoint: 0.0.0.0:4318 }
+          grpc: { endpoint: 0.0.0.0:4317 }
+    processors:
+      batch: {}
+    exporters:
+      otlp/tempo:
+        endpoint: {{ $rel }}-tempo:4317
+        tls: { insecure: true }
+      debug: { verbosity: basic }
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp/tempo, debug]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $rel }}-otel-collector
+  labels: { app.kubernetes.io/name: otel-collector }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app.kubernetes.io/name: otel-collector, app.kubernetes.io/instance: {{ $rel }} } }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: otel-collector, app.kubernetes.io/instance: {{ $rel }} }
+    spec:
+      containers:
+        - name: otel-collector
+          image: {{ $o.otelCollector.image }}
+          args: ["--config=/etc/otelcol/config.yaml"]
+          ports:
+            - { name: otlp-http, containerPort: 4318 }
+            - { name: otlp-grpc, containerPort: 4317 }
+          volumeMounts: [{ name: config, mountPath: /etc/otelcol }]
+      volumes:
+        - name: config
+          configMap: { name: {{ $rel }}-otel-collector }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $rel }}-otel-collector
+  labels: { app.kubernetes.io/name: otel-collector }
+spec:
+  selector: { app.kubernetes.io/name: otel-collector, app.kubernetes.io/instance: {{ $rel }} }
+  ports:
+    - { name: otlp-http, port: 4318, targetPort: 4318 }
+    - { name: otlp-grpc, port: 4317, targetPort: 4317 }
+---
+# ---------------- Tempo ----------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $rel }}-tempo
+  labels: { app.kubernetes.io/name: tempo }
+data:
+  tempo.yaml: |
+    server:
+      http_listen_port: 3200
+    distributor:
+      receivers:
+        otlp:
+          protocols:
+            grpc: { endpoint: 0.0.0.0:4317 }
+            http: { endpoint: 0.0.0.0:4318 }
+    ingester:
+      trace_idle_period: 10s
+    compactor:
+      compaction:
+        block_retention: 168h
+    storage:
+      trace:
+        backend: local
+        local: { path: /var/tempo/traces }
+        wal: { path: /var/tempo/wal }
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $rel }}-tempo
+  labels: { app.kubernetes.io/name: tempo }
+spec:
+  serviceName: {{ $rel }}-tempo
+  replicas: 1
+  selector: { matchLabels: { app.kubernetes.io/name: tempo, app.kubernetes.io/instance: {{ $rel }} } }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: tempo, app.kubernetes.io/instance: {{ $rel }} }
+    spec:
+      containers:
+        - name: tempo
+          image: {{ $o.tempo.image }}
+          args: ["-config.file=/etc/tempo/tempo.yaml"]
+          ports:
+            - { name: http, containerPort: 3200 }
+            - { name: otlp-grpc, containerPort: 4317 }
+          volumeMounts:
+            - { name: config, mountPath: /etc/tempo }
+            - { name: data, mountPath: /var/tempo }
+      volumes:
+        - name: config
+          configMap: { name: {{ $rel }}-tempo }
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- with $o.tempo.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources: { requests: { storage: {{ $o.tempo.storage }} } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $rel }}-tempo
+  labels: { app.kubernetes.io/name: tempo }
+spec:
+  selector: { app.kubernetes.io/name: tempo, app.kubernetes.io/instance: {{ $rel }} }
+  ports:
+    - { name: http, port: 3200, targetPort: 3200 }
+    - { name: otlp-grpc, port: 4317, targetPort: 4317 }
+---
+# ---------------- Prometheus ----------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $rel }}-prometheus
+  labels: { app.kubernetes.io/name: prometheus }
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: {{ $o.prometheus.scrapeInterval }}
+    scrape_configs:
+      - job_name: gateway
+        metrics_path: /actuator/prometheus
+        static_configs:
+          - targets: ["{{ $rel }}-gateway:{{ .Values.gateway.port }}"]
+      - job_name: gebo-microservices
+        relabel_configs:
+          - source_labels: [__meta_context_path]
+            target_label: __metrics_path__
+            regex: (.+)
+            replacement: ${1}/actuator/prometheus
+        static_configs:
+{{- range $name, $svc := .Values.backends }}
+{{- if include "gebo.backendEnabled" $svc }}
+          - targets: ["{{ $rel }}-{{ $name }}:{{ $svc.port }}"]
+            labels: { service: {{ $name }}, __meta_context_path: /{{ $name }} }
+{{- end }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $rel }}-prometheus
+  labels: { app.kubernetes.io/name: prometheus }
+spec:
+  serviceName: {{ $rel }}-prometheus
+  replicas: 1
+  selector: { matchLabels: { app.kubernetes.io/name: prometheus, app.kubernetes.io/instance: {{ $rel }} } }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: prometheus, app.kubernetes.io/instance: {{ $rel }} }
+    spec:
+      containers:
+        - name: prometheus
+          image: {{ $o.prometheus.image }}
+          args: ["--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus"]
+          ports: [{ name: http, containerPort: 9090 }]
+          volumeMounts:
+            - { name: config, mountPath: /etc/prometheus }
+            - { name: data, mountPath: /prometheus }
+      volumes:
+        - name: config
+          configMap: { name: {{ $rel }}-prometheus }
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- with $o.prometheus.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources: { requests: { storage: {{ $o.prometheus.storage }} } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $rel }}-prometheus
+  labels: { app.kubernetes.io/name: prometheus }
+spec:
+  selector: { app.kubernetes.io/name: prometheus, app.kubernetes.io/instance: {{ $rel }} }
+  ports: [{ name: http, port: 9090, targetPort: 9090 }]
+---
+# ---------------- Grafana ----------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $rel }}-grafana-provisioning
+  labels: { app.kubernetes.io/name: grafana }
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        uid: gebo-prometheus
+        type: prometheus
+        access: proxy
+        url: http://{{ $rel }}-prometheus:9090
+        isDefault: true
+        editable: false
+      - name: Tempo
+        uid: gebo-tempo
+        type: tempo
+        access: proxy
+        url: http://{{ $rel }}-tempo:3200
+        editable: false
+        jsonData:
+          tracesToMetrics: { datasourceUid: gebo-prometheus }
+          serviceMap: { datasourceUid: gebo-prometheus }
+          nodeGraph: { enabled: true }
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: Gebo default dashboards
+        orgId: 1
+        folder: ""
+        type: file
+        disableDeletion: false
+        updateIntervalSeconds: 30
+        allowUiUpdates: true
+        options:
+          path: /etc/grafana/provisioning/dashboards
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $rel }}-grafana-dashboards
+  labels: { app.kubernetes.io/name: grafana }
+data:
+  gebo-overview.json: |
+{{ .Files.Get "files/gebo-overview.json" | indent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $rel }}-grafana
+  labels: { app.kubernetes.io/name: grafana }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app.kubernetes.io/name: grafana, app.kubernetes.io/instance: {{ $rel }} } }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: grafana, app.kubernetes.io/instance: {{ $rel }} }
+    spec:
+      containers:
+        - name: grafana
+          image: {{ $o.grafana.image }}
+          ports: [{ name: http, containerPort: 3000 }]
+          env:
+            - { name: GF_AUTH_ANONYMOUS_ENABLED, value: {{ $o.grafana.anonymousViewer | quote }} }
+            - { name: GF_AUTH_ANONYMOUS_ORG_ROLE, value: Viewer }
+          volumeMounts:
+            - { name: provisioning-datasources, mountPath: /etc/grafana/provisioning/datasources }
+            - { name: provisioning-dashboards-cfg, mountPath: /etc/grafana/provisioning/dashboards }
+      volumes:
+        - name: provisioning-datasources
+          configMap:
+            name: {{ $rel }}-grafana-provisioning
+            items: [{ key: datasources.yaml, path: datasources.yaml }]
+        - name: provisioning-dashboards-cfg
+          projected:
+            sources:
+              - configMap:
+                  name: {{ $rel }}-grafana-provisioning
+                  items: [{ key: dashboards.yaml, path: dashboards.yaml }]
+              - configMap:
+                  name: {{ $rel }}-grafana-dashboards
+                  items: [{ key: gebo-overview.json, path: gebo-overview.json }]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $rel }}-grafana
+  labels: { app.kubernetes.io/name: grafana }
+spec:
+  type: {{ $o.grafana.service.type }}
+  selector: { app.kubernetes.io/name: grafana, app.kubernetes.io/instance: {{ $rel }} }
+  ports: [{ name: http, port: 3000, targetPort: 3000 }]
+{{- end }}

--- a/deploy/helm/gebo-microservices/templates/secret.yaml
+++ b/deploy/helm/gebo-microservices/templates/secret.yaml
@@ -1,0 +1,21 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+  labels:
+    {{- include "gebo.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # Consumed as env vars (envFrom) by every backend; the shared application.yml
+  # references them as ${...} placeholders (Spring relaxed binding).
+  GEBO_TOKEN_SECRET: {{ .Values.secrets.tokenSecret | quote }}
+  MONGO_USERNAME: {{ .Values.secrets.mongoUsername | quote }}
+  MONGO_PASSWORD: {{ .Values.secrets.mongoPassword | quote }}
+  RABBITMQ_PASSWORD: {{ .Values.secrets.rabbitPassword | quote }}
+  QDRANT_API_KEY: {{ .Values.secrets.qdrantApiKey | quote }}
+  NEO4J_PASSWORD: {{ .Values.secrets.neo4jPassword | quote }}
+  OPENSEARCH_PASSWORD: {{ .Values.secrets.opensearchPassword | quote }}
+  OPENAI_API_KEY: {{ .Values.secrets.openaiApiKey | quote }}
+  ANTHROPIC_API_KEY: {{ .Values.secrets.anthropicApiKey | quote }}
+{{- end }}

--- a/deploy/helm/gebo-microservices/values.yaml
+++ b/deploy/helm/gebo-microservices/values.yaml
@@ -172,6 +172,30 @@ secrets:
   openaiApiKey: "DUMMYKEY"
   anthropicApiKey: "DUMMYKEY"
 
+# --- Observability stack (otel-collector + Prometheus + Tempo + Grafana) ---
+# Off by default. When enabled, backends export traces to the in-cluster collector
+# (overrides common.otlpTracingEndpoint), Tempo stores them, Prometheus scrapes the
+# enabled backends' /actuator/prometheus, and Grafana ships with both datasources +
+# a starter dashboard. Mirrors dockers/gebo.microservices observability config.
+observability:
+  enabled: false
+  otelCollector:
+    image: otel/opentelemetry-collector-contrib:latest
+  tempo:
+    image: grafana/tempo
+    storage: 5Gi
+    storageClassName: ""
+  prometheus:
+    image: prom/prometheus
+    scrapeInterval: 15s
+    storage: 5Gi
+    storageClassName: ""
+  grafana:
+    image: grafana/grafana
+    service:
+      type: ClusterIP        # LoadBalancer/NodePort to expose the UI
+    anonymousViewer: true
+
 # --- Extra shared application.yml -----------------------------------------
 # Verbatim YAML appended to the shared config additional-location (advanced).
 extraSharedConfig: ""

--- a/deploy/helm/gebo-microservices/values.yaml
+++ b/deploy/helm/gebo-microservices/values.yaml
@@ -1,0 +1,177 @@
+# ===========================================================================
+# Gebo.ai microservices — Helm values.
+#
+# The headline is `backends.<svc>.enabled`: mandatory services are always
+# rendered (a template guard fails the install if you try to disable one);
+# optional services are gated. Whatever you enable also defines the declared
+# messaging topology (see templates/configmap-shared.yaml), so the topology can
+# never drift from what is actually deployed.
+#
+# Mirrors dockers/gebo.microservices/docker-compose.yml + its config/application.yml.
+# CHANGE EVERY SECRET before any non-dev use (see `secrets:` below).
+# ===========================================================================
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  # Optional registry prefix, WITH trailing slash, e.g. "myregistry.example.com/".
+  # Empty => Docker Hub. Combined as: {{ registry }}{{ namespace }}/<svc>.gebo.ai:{{ tag }}
+  registry: ""
+  namespace: geboai
+  tag: "1.0.2.0-SNAPSHOT"
+  pullPolicy: IfNotPresent
+imagePullSecrets: []          # e.g. [{ name: regcred }]
+
+# Applied to every backend (mirrors the compose x-microservice env).
+common:
+  javaToolOptions: "-Xms256m -Xmx1g"
+  managementExposure: "health,prometheus,metrics"
+  # OTLP traces endpoint; empty disables trace export.
+  otlpTracingEndpoint: ""
+  tracingSamplingProbability: "1.0"
+  # extra env applied to every backend: [{name: X, value: "y"}]
+  extraEnv: []
+
+# Default compute resources for every backend (override per service under backends.<svc>.resources).
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    memory: 1536Mi
+
+# --- Service registry (Eureka) --------------------------------------------
+eureka:
+  port: 13017
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits: { memory: 768Mi }
+
+# --- API gateway (the edge) -----------------------------------------------
+gateway:
+  port: 13000
+  service:
+    type: ClusterIP           # LoadBalancer/NodePort to expose without an Ingress
+  ingress:
+    enabled: false
+    className: ""
+    host: gebo.local
+    annotations: {}
+    tls:
+      enabled: false
+      secretName: ""
+  resources:
+    requests: { cpu: 200m, memory: 384Mi }
+    limits: { memory: 1024Mi }
+
+# --- Backends -------------------------------------------------------------
+# mandatory: true  -> always installed; `enabled:false` on it FAILS the install.
+# enabled (optional ones): default true; set false to leave the service out.
+# The messaging topology ConfigMap is rendered from exactly the enabled set.
+backends:
+  # ---- Mandatory core ----
+  heimdall:     { port: 13018, mandatory: true }
+  brain:        { port: 13001, mandatory: true }
+  tyr:          { port: 13019, mandatory: true }
+  chunker:      { port: 13004, mandatory: true }
+  vectorizator: { port: 13002, mandatory: true }
+  # ---- Optional workflow performers ----
+  graphicator:  { port: 13003, enabled: true }   # graphrag; needs neo4j
+  fulltextor:   { port: 13016, enabled: true }   # full-text; needs opensearch
+  # ---- Optional per-connector content handlers ----
+  git:          { port: 13005, enabled: true }
+  filesystem:   { port: 13006, enabled: true }
+  uploads:      { port: 13007, enabled: true }
+  userspace:    { port: 13008, enabled: true }
+  sharepoint:   { port: 13009, enabled: true }
+  confluence:   { port: 13010, enabled: true }
+  jira:         { port: 13011, enabled: true }
+  aws-s3:       { port: 13012, enabled: true }
+  googledrive:  { port: 13013, enabled: true }
+  mcpclient:    { port: 13014, enabled: true }
+  integration:  { port: 13015, enabled: true }
+
+# --- Stateful dependencies -------------------------------------------------
+# enabled:true  -> deployed in-cluster (StatefulSet + PVC + Service).
+# enabled:false -> not deployed; the app points at `external.*` instead.
+infra:
+  mongodb:
+    enabled: true
+    image: mongo:7
+    rootUsername: mongoroot         # password from secrets.mongoPassword
+    storage: 10Gi
+    storageClassName: ""
+    external:
+      # used when enabled:false. Placeholders ${...} resolve from the Secret.
+      connectionString: "mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@mongo:27017/?authSource=admin"
+  rabbitmq:
+    enabled: true
+    image: rabbitmq:3-management
+    username: guest                 # password from secrets.rabbitPassword
+    external:
+      host: rabbit
+      port: 5672
+  qdrant:
+    enabled: true
+    image: qdrant/qdrant
+    storage: 10Gi
+    storageClassName: ""
+    external:
+      host: qdrant
+      port: 6334
+      tls: false
+  neo4j:
+    enabled: true
+    image: neo4j:5
+    username: neo4j                 # password from secrets.neo4jPassword
+    storage: 10Gi
+    storageClassName: ""
+    external:
+      uri: "bolt://neo4j:7687"
+  opensearch:
+    enabled: true
+    image: opensearchproject/opensearch:latest
+    storage: 10Gi
+    storageClassName: ""
+    javaOpts: "-Xms1g -Xmx1g"
+    external:
+      protocol: https
+      host: opensearch
+      port: 9200
+      username: admin              # password from secrets.opensearchPassword
+
+# --- Security (CORS / OAuth2 redirect) -------------------------------------
+security:
+  # Browser origins allowed to call the API (the gateway edge + any dev server).
+  corsAllowedOrigins: "http://localhost:13000,http://localhost:4200"
+
+# --- LLM providers (non-secret flags; keys live in secrets) ----------------
+llm:
+  openAIEnabled: true
+  anthropicEnabled: true
+  ollamaEnabled: true
+  openaiEmbeddingModel: text-embedding-3-large
+  openaiChatModel: gpt-3.5-turbo-16k
+
+# --- Secrets ---------------------------------------------------------------
+# DEV DEFAULTS — override for production, or set existingSecret to bring your own.
+# When existingSecret is set, it must provide the same KEYS this chart's Secret does
+# (see templates/secret.yaml): GEBO_TOKEN_SECRET, MONGO_USERNAME, MONGO_PASSWORD,
+# RABBITMQ_PASSWORD, QDRANT_API_KEY, NEO4J_PASSWORD, OPENSEARCH_PASSWORD,
+# OPENAI_API_KEY, ANTHROPIC_API_KEY.
+secrets:
+  existingSecret: ""
+  tokenSecret: "04ca023b39512e46d0c2cf4b48d5aac61d34302994c87ed4eff225dcf3b0a218739f3897051a057f9b846a69ea2927a587044164b7bae5e1306219d50b588cb1"
+  mongoUsername: "mongoroot"
+  mongoPassword: "mongopwd"
+  rabbitPassword: "guest"
+  qdrantApiKey: "ce7c85bc-f037-4c64-91d8-70335638329d"
+  neo4jPassword: "neo4jmaster"
+  opensearchPassword: "dothesearch1973-Advanced"
+  openaiApiKey: "DUMMYKEY"
+  anthropicApiKey: "DUMMYKEY"
+
+# --- Extra shared application.yml -----------------------------------------
+# Verbatim YAML appended to the shared config additional-location (advanced).
+extraSharedConfig: ""

--- a/gebo.microservices.architecture.parent/gebo.microservices.topology/src/main/java/ai/gebo/microservices/topology/config/GeboMicroservicesTopologyAutoConfiguration.java
+++ b/gebo.microservices.architecture.parent/gebo.microservices.topology/src/main/java/ai/gebo/microservices/topology/config/GeboMicroservicesTopologyAutoConfiguration.java
@@ -64,6 +64,16 @@ public class GeboMicroservicesTopologyAutoConfiguration {
 		properties.getServices()
 				.forEach((microserviceId, modules) -> merged.put(microserviceId, modules == null ? Map.of() : modules));
 
+		// Deny-list applied last: drop the microservices this installation does not deploy,
+		// so a subset install keeps include-defaults=true and only lists what is absent.
+		if (properties.getDisabledServices() != null) {
+			for (String disabled : properties.getDisabledServices()) {
+				if (disabled != null && !disabled.isBlank()) {
+					merged.remove(GeboMicroservice.normalizeName(disabled));
+				}
+			}
+		}
+
 		List<GeboMicroservice> microservices = merged.entrySet().stream()
 				.map(entry -> new GeboMicroservice(entry.getKey(), entry.getValue())).toList();
 

--- a/gebo.microservices.architecture.parent/gebo.microservices.topology/src/main/java/ai/gebo/microservices/topology/config/GeboMicroservicesTopologyProperties.java
+++ b/gebo.microservices.architecture.parent/gebo.microservices.topology/src/main/java/ai/gebo/microservices/topology/config/GeboMicroservicesTopologyProperties.java
@@ -9,6 +9,7 @@
 
 package ai.gebo.microservices.topology.config;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,16 @@ public class GeboMicroservicesTopologyProperties {
 	private Map<String, Map<String, List<String>>> services = new LinkedHashMap<>();
 
 	/**
+	 * Microservice ids to REMOVE from the resolved topology (a deny-list applied
+	 * last, after defaults + {@link #services}). This is how a heterogeneous
+	 * installation declares a subset without having to re-specify every module map:
+	 * keep {@code include-defaults=true} and list the microservices that are NOT
+	 * deployed here. Ids may be dotted or underscore form. Mandatory services are
+	 * simply never listed, so they cannot be dropped by accident.
+	 */
+	private List<String> disabledServices = new ArrayList<>();
+
+	/**
 	 * Microservice ids that participate in the LLM models-replication cache. This
 	 * is part of the <b>shared</b> topology configuration: when {@code null} (the
 	 * default) the built-in
@@ -98,6 +109,14 @@ public class GeboMicroservicesTopologyProperties {
 
 	public void setServices(Map<String, Map<String, List<String>>> services) {
 		this.services = services;
+	}
+
+	public List<String> getDisabledServices() {
+		return disabledServices;
+	}
+
+	public void setDisabledServices(List<String> disabledServices) {
+		this.disabledServices = disabledServices;
 	}
 
 	public List<String> getModelsReplicationParticipants() {


### PR DESCRIPTION
Adds a Helm chart to automate installing the Gebo.ai microservices on Kubernetes, plus the small topology enhancement that makes heterogeneous (subset) installs clean.

## `deploy/helm/gebo-microservices/`
Installs the Eureka registry, the API gateway edge, and every backend microservice; optionally deploys the stateful dependencies (MongoDB, RabbitMQ, Qdrant, Neo4j, OpenSearch) **in-cluster and toggleable**, or points them at external/managed instances. Mirrors `dockers/gebo.microservices/docker-compose.yml` + its `config/application.yml`.

**Optional / mandatory:** `backends.<svc>.enabled` gates optional services; mandatory ones (`heimdall`, `brain`, `tyr`, `chunker`, `vectorizator` + `eureka` + `gateway`) are always rendered and **cannot be disabled** (a template guard fails the install). The enabled set also drives the declared messaging topology, so **declared == deployed** — no drift for the tyr coordinator / workflow-step enablement to trip over.

Keeps **Eureka** + client-side load balancing (registering by pod IP); secrets are a `Secret` (env vars) referenced as `${...}` placeholders in the shared config; `tcpSocket` probes (the actuator health endpoint sits behind the service context-path and requires auth).

## Topology enhancement (app)
`gebo.microservices.topology.disabled-services` — a deny-list applied after defaults + `services`. Keep `include-defaults: true` and list the microservices **not** deployed here; module maps still come from `GeboStandardMicroservices.DEFAULTS`, and mandatory services are never listed so they cannot be dropped by accident. This is what lets the chart declare a subset topology without duplicating every module map (and avoids the empty-map config-binding pitfall of reconstructing the `services` map).

## Validation
`helm lint` + `helm template` clean. Deployed to a local **kind** cluster (images loaded directly, no registry): a mandatory-only subset (`graphicator`/`fulltextor`/all content-handlers off, `neo4j`/`opensearch` off) comes up **10/10 Ready**, with the config declaring `include-defaults:true` + 13 `disabled-services` → topology = the 5 deployed backends. The live test also drove three chart fixes (topology binding, the required `cors.allowedOrigins` key, tcpSocket probes).

> Not included: observability stack (point `common.otlpTracingEndpoint` at your own collector); production hardening of the in-cluster StatefulSets. Images must be pushed to a registry the cluster can pull (jib `build`, not `buildTar`).