### PR TITLE
fix(microservices): repair auto-configuration ordering across all microservice apps, add context tests

### DIFF
--- a/gebo.api.clients/gebo.microservices.clients.parent/aws-s3.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/aws-s3.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-aws-s3-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-aws-s3-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/brain.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/brain.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-brain-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-brain-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/chunker.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/chunker.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-chunker-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-chunker-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/confluence.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/confluence.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-confluence-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-confluence-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/eureka.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/eureka.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-eureka-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-eureka-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/filesystem.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/filesystem.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-filesystem-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-filesystem-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/fulltextor.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/fulltextor.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-fulltextor-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-fulltextor-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/gateway.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/gateway.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-gateway-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-gateway-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/git.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/git.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-git-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-git-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/googledrive.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/googledrive.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-googledrive-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-googledrive-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/graphicator.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/graphicator.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-graphicator-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-graphicator-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/heimdall.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/heimdall.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-heimdall-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-heimdall-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/integration.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/integration.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-integration-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-integration-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/jira.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/jira.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-jira-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-jira-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/mcpclient.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/mcpclient.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-mcpclient-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-mcpclient-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/sharepoint.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/sharepoint.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-sharepoint-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-sharepoint-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/tyr.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/tyr.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-tyr-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-tyr-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/uploads.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/uploads.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-uploads-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-uploads-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/userspace.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/userspace.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-userspace-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-userspace-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.api.clients/gebo.microservices.clients.parent/vectorizator.gebo.ai.angular.client/package-lock.json
+++ b/gebo.api.clients/gebo.microservices.clients.parent/vectorizator.gebo.ai.angular.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-vectorizator-client",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-vectorizator-client",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/common": "^21.2.18",

--- a/gebo.apps.parent/gebo.microservices.apps.parent/aws-s3.gebo.ai/src/main/java/ai/gebo/microservices/awss3/AwsS3Application.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/aws-s3.gebo.ai/src/main/java/ai/gebo/microservices/awss3/AwsS3Application.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.awss3;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (aws-s3's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/aws-s3.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/aws-s3.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: aws-s3-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/aws-s3.gebo.ai/src/test/java/ai/gebo/microservices/awss3/AwsS3ContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/aws-s3.gebo.ai/src/test/java/ai/gebo/microservices/awss3/AwsS3ContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.awss3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
+
+/**
+ * awss3 actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation - this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, AwsS3Application's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as
+ * an ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter}
+ * ordering for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration).
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { AwsS3Application.class, AwsS3ContextTest.DiscoveryStubConfig.class })
+class AwsS3ContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("awss3-home");
+			Path work = Files.createTempDirectory("awss3-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the awss3 test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: awss3 owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** awss3's own content-handler surface still comes up alongside all of the above. */
+	@Test
+	void publishesItsOwnContentHandler() {
+		assertThat(context.getBeansOfType(IGContentManagementSystemHandler.class)).isNotEmpty();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/brain.gebo.ai/src/main/java/ai/gebo/microservices/brain/BrainApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/brain.gebo.ai/src/main/java/ai/gebo/microservices/brain/BrainApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.brain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (brain's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/brain.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/brain.gebo.ai/src/main/resources/application.yml
@@ -43,6 +43,18 @@ eureka:
     secure-virtual-host-name: brain-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/brain.gebo.ai/src/test/java/ai/gebo/microservices/brain/BrainContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/brain.gebo.ai/src/test/java/ai/gebo/microservices/brain/BrainContextTest.java
@@ -1,0 +1,159 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.brain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.microservices.models.replication.DiscoveryClientClusterTopologyProvider;
+import ai.gebo.architecture.hazelcast.IGModelsReplicationClusterTopologyProvider;
+import ai.gebo.microservices.searchservices.client.JiraSearchServiceRestClient;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+
+/**
+ * brain actually starts, and it resolves the secrets/security/ACL directories
+ * through the REMOTE (heimdall) clients rather than any local implementation,
+ * seeds its models-replication cache membership from LIVE discovery, and wires
+ * the search-service clients its agents call out to.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, {@code BrainApplication}'s
+ * {@code @ComponentScan(basePackages = "ai.gebo")} drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated, which would silently defeat {@code @AutoConfigureAfter} ordering.
+ * brain is the clearest case: its own
+ * {@code ModelsReplicationClusterAutoConfiguration} publishes the
+ * discovery-backed {@code IGModelsReplicationClusterTopologyProvider} only
+ * {@code @ConditionalOnBean(DiscoveryClient.class)} - exactly the pattern that
+ * silently produced the WRONG (name-based fallback) provider in heimdall before
+ * the fix, with no error, just a less-accurate cluster view.
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { BrainApplication.class, BrainContextTest.DiscoveryStubConfig.class })
+class BrainContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("brain-home");
+			Path work = Files.createTempDirectory("brain-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the brain test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: brain owns none of secrets, the security
+	 * directory or the ACL store, so all three must resolve to their REST client
+	 * implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/**
+	 * brain is a default models-replication participant, and a
+	 * {@link DiscoveryClient} is available (a stub here, Eureka's in production),
+	 * so the topology provider must be the discovery-backed one - never the
+	 * static-name fallback that only exists for a deployment with no discovery.
+	 */
+	@Test
+	void seedsModelsReplicationFromLiveDiscovery() {
+		assertThat(context.getBean(IGModelsReplicationClusterTopologyProvider.class))
+				.isInstanceOf(DiscoveryClientClusterTopologyProvider.class);
+	}
+
+	/** The search-service clients brain's agents reach out to. */
+	@Test
+	void publishesSearchServiceClients() {
+		assertThat(context.getBean(JiraSearchServiceRestClient.class)).isNotNull();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/chunker.gebo.ai/src/main/java/ai/gebo/microservices/chunker/ChunkerApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/chunker.gebo.ai/src/main/java/ai/gebo/microservices/chunker/ChunkerApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.chunker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (chunker's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/chunker.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/chunker.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,17 @@ eureka:
     secure-virtual-host-name: chunker-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though chunker has no AuthController of its own. In the docker
+# stack the shared config overlay supplies the real value; this is the standalone
+# default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/chunker.gebo.ai/src/test/java/ai/gebo/microservices/chunker/ChunkerContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/chunker.gebo.ai/src/test/java/ai/gebo/microservices/chunker/ChunkerContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.chunker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.microservices.workflow.steps.IWorkflowParticipantsEnablementResolver;
+
+/**
+ * chunker actually starts, and it resolves the secrets/security/ACL directories
+ * through the REMOTE (heimdall) clients rather than any local implementation -
+ * this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, chunker's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as an
+ * ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter} ordering
+ * for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration). This test is what would have caught it.
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { ChunkerApplication.class, ChunkerContextTest.DiscoveryStubConfig.class })
+class ChunkerContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("chunker-home");
+			Path work = Files.createTempDirectory("chunker-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the chunker test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: chunker owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** chunker's workflow-step enablement resolver (per tyr's authority) still wires up. */
+	@Test
+	void publishesWorkflowStepEnablement() {
+		assertThat(context.getBean(IWorkflowParticipantsEnablementResolver.class)).isNotNull();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/confluence.gebo.ai/src/main/java/ai/gebo/microservices/confluence/ConfluenceApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/confluence.gebo.ai/src/main/java/ai/gebo/microservices/confluence/ConfluenceApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.confluence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (confluence's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/confluence.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/confluence.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: confluence-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/confluence.gebo.ai/src/test/java/ai/gebo/microservices/confluence/ConfluenceContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/confluence.gebo.ai/src/test/java/ai/gebo/microservices/confluence/ConfluenceContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.confluence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
+
+/**
+ * confluence actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation - this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, ConfluenceApplication's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as
+ * an ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter}
+ * ordering for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration).
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { ConfluenceApplication.class, ConfluenceContextTest.DiscoveryStubConfig.class })
+class ConfluenceContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("confluence-home");
+			Path work = Files.createTempDirectory("confluence-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the confluence test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: confluence owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** confluence's own content-handler surface still comes up alongside all of the above. */
+	@Test
+	void publishesItsOwnContentHandler() {
+		assertThat(context.getBeansOfType(IGContentManagementSystemHandler.class)).isNotEmpty();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/filesystem.gebo.ai/src/main/java/ai/gebo/microservices/filesystem/FilesystemApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/filesystem.gebo.ai/src/main/java/ai/gebo/microservices/filesystem/FilesystemApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.filesystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (filesystem's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/filesystem.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/filesystem.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: filesystem-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/filesystem.gebo.ai/src/test/java/ai/gebo/microservices/filesystem/FilesystemContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/filesystem.gebo.ai/src/test/java/ai/gebo/microservices/filesystem/FilesystemContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.filesystem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
+
+/**
+ * filesystem actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation - this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, FilesystemApplication's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as
+ * an ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter}
+ * ordering for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration).
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { FilesystemApplication.class, FilesystemContextTest.DiscoveryStubConfig.class })
+class FilesystemContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("filesystem-home");
+			Path work = Files.createTempDirectory("filesystem-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the filesystem test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: filesystem owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** filesystem's own content-handler surface still comes up alongside all of the above. */
+	@Test
+	void publishesItsOwnContentHandler() {
+		assertThat(context.getBeansOfType(IGContentManagementSystemHandler.class)).isNotEmpty();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/fulltextor.gebo.ai/src/main/java/ai/gebo/microservices/fulltextor/FulltextorApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/fulltextor.gebo.ai/src/main/java/ai/gebo/microservices/fulltextor/FulltextorApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.fulltextor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -34,7 +37,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (fulltextor's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/fulltextor.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/fulltextor.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: fulltextor-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/fulltextor.gebo.ai/src/test/java/ai/gebo/microservices/fulltextor/FulltextorContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/fulltextor.gebo.ai/src/test/java/ai/gebo/microservices/fulltextor/FulltextorContextTest.java
@@ -1,0 +1,140 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.fulltextor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.documents.cache.client.DocumentsCacheServiceRestClient;
+import ai.gebo.architecture.documents.cache.service.IDocumentsCacheService;
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+
+/**
+ * fulltextor actually starts, and it resolves the secrets/security/ACL directories
+ * through the REMOTE (heimdall) clients rather than any local implementation, plus
+ * the document-cache client it uses to fetch content from the chunker.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, {@code FulltextorApplication}'s
+ * {@code @ComponentScan(basePackages = "ai.gebo")} drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated, which would silently defeat {@code @AutoConfigureAfter} ordering for
+ * the client auto-configurations this service depends on.
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { FulltextorApplication.class, FulltextorContextTest.DiscoveryStubConfig.class })
+class FulltextorContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("fulltextor-home");
+			Path work = Files.createTempDirectory("fulltextor-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the fulltextor test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: fulltextor owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** The document-cache client used to fetch content from the chunker it doesn't own. */
+	@Test
+	void resolvesTheDocumentsCacheClient() {
+		assertThat(context.getBean(IDocumentsCacheService.class)).isInstanceOf(DocumentsCacheServiceRestClient.class);
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/git.gebo.ai/src/main/java/ai/gebo/microservices/git/GitApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/git.gebo.ai/src/main/java/ai/gebo/microservices/git/GitApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.git;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (git's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/git.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/git.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: git-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/git.gebo.ai/src/test/java/ai/gebo/microservices/git/GitContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/git.gebo.ai/src/test/java/ai/gebo/microservices/git/GitContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.git;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
+
+/**
+ * git actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation - this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, GitApplication's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as
+ * an ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter}
+ * ordering for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration).
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { GitApplication.class, GitContextTest.DiscoveryStubConfig.class })
+class GitContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("git-home");
+			Path work = Files.createTempDirectory("git-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the git test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: git owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** git's own content-handler surface still comes up alongside all of the above. */
+	@Test
+	void publishesItsOwnContentHandler() {
+		assertThat(context.getBeansOfType(IGContentManagementSystemHandler.class)).isNotEmpty();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/googledrive.gebo.ai/src/main/java/ai/gebo/microservices/googledrive/GoogleDriveApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/googledrive.gebo.ai/src/main/java/ai/gebo/microservices/googledrive/GoogleDriveApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.googledrive;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (googledrive's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/googledrive.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/googledrive.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: googledrive-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/googledrive.gebo.ai/src/test/java/ai/gebo/microservices/googledrive/GoogleDriveContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/googledrive.gebo.ai/src/test/java/ai/gebo/microservices/googledrive/GoogleDriveContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.googledrive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
+
+/**
+ * googledrive actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation - this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, GoogleDriveApplication's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as
+ * an ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter}
+ * ordering for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration).
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { GoogleDriveApplication.class, GoogleDriveContextTest.DiscoveryStubConfig.class })
+class GoogleDriveContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("googledrive-home");
+			Path work = Files.createTempDirectory("googledrive-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the googledrive test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: googledrive owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** googledrive's own content-handler surface still comes up alongside all of the above. */
+	@Test
+	void publishesItsOwnContentHandler() {
+		assertThat(context.getBeansOfType(IGContentManagementSystemHandler.class)).isNotEmpty();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/graphicator.gebo.ai/src/main/java/ai/gebo/microservices/graphicator/GraphicatorApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/graphicator.gebo.ai/src/main/java/ai/gebo/microservices/graphicator/GraphicatorApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.graphicator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -34,7 +37,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (graphicator's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/graphicator.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/graphicator.gebo.ai/src/main/resources/application.yml
@@ -37,6 +37,18 @@ eureka:
     secure-virtual-host-name: graphicator-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/graphicator.gebo.ai/src/test/java/ai/gebo/microservices/graphicator/GraphicatorContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/graphicator.gebo.ai/src/test/java/ai/gebo/microservices/graphicator/GraphicatorContextTest.java
@@ -1,0 +1,152 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.graphicator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.microservices.models.replication.DiscoveryClientClusterTopologyProvider;
+import ai.gebo.architecture.hazelcast.IGModelsReplicationClusterTopologyProvider;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+
+/**
+ * graphicator actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation, and correctly seeds its models-replication cache membership
+ * from LIVE discovery rather than the static-name fallback.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, GraphicatorApplication's
+ * {@code @ComponentScan(basePackages = "ai.gebo")} drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated, which would silently defeat {@code @AutoConfigureAfter} ordering.
+ * graphicator is the clearest case: its own
+ * {@code ModelsReplicationClusterAutoConfiguration} publishes the
+ * discovery-backed {@code IGModelsReplicationClusterTopologyProvider} only
+ * {@code @ConditionalOnBean(DiscoveryClient.class)} - exactly the pattern that
+ * silently produced the WRONG (name-based fallback) provider in heimdall before
+ * the fix, with no error, just a less-accurate cluster view.
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { GraphicatorApplication.class, GraphicatorContextTest.DiscoveryStubConfig.class })
+class GraphicatorContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("graphicator-home");
+			Path work = Files.createTempDirectory("graphicator-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the graphicator test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: graphicator owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/**
+	 * graphicator is a default models-replication participant, and a
+	 * {@link DiscoveryClient} is available (a stub here, Eureka's in production),
+	 * so the topology provider must be the discovery-backed one - never the
+	 * static-name fallback that only exists for a deployment with no discovery.
+	 */
+	@Test
+	void seedsModelsReplicationFromLiveDiscovery() {
+		assertThat(context.getBean(IGModelsReplicationClusterTopologyProvider.class))
+				.isInstanceOf(DiscoveryClientClusterTopologyProvider.class);
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/heimdall.gebo.ai/src/main/java/ai/gebo/microservices/heimdall/HeimdallApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/heimdall.gebo.ai/src/main/java/ai/gebo/microservices/heimdall/HeimdallApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.heimdall;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -50,7 +53,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (heimdall's own production beans live in
+// ai.gebo.secrets/security/acl.*, well outside ai.gebo.microservices.heimdall),
+// but @ComponentScan given DIRECTLY on the class replaces - rather than merges
+// with - the one @SpringBootApplication supplies, so its default excludeFilters
+// (TypeExcludeFilter, AutoConfigurationExcludeFilter) are lost unless restated
+// here. Without AutoConfigurationExcludeFilter, plain component-scanning picks up
+// every @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as
+// an ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for GeboClusterCommonsAutoConfiguration and
+// the cluster controller auto-configurations that depend on it.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/heimdall.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/heimdall.gebo.ai/src/main/resources/application.yml
@@ -71,6 +71,12 @@ ai:
         enabled: true
         base-path: api/cluster/SecretsController
     security:
+      # heimdall hosts AuthController (see WebMvcConfig in gebo.architecture.security),
+      # so it needs this like any other browser-facing service. No cluster-internal
+      # endpoint is covered by this CORS mapping - those are guarded by
+      # GeboClusterParticipants instead, on caller address, not by origin.
+      cors:
+        allowedOrigins: ${GEBO_UI_ORIGIN:http://localhost:4200}
       cluster:
         enabled: true
         base-path: api/cluster/SecurityController

--- a/gebo.apps.parent/gebo.microservices.apps.parent/integration.gebo.ai/src/main/java/ai/gebo/microservices/integration/IntegrationApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/integration.gebo.ai/src/main/java/ai/gebo/microservices/integration/IntegrationApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.integration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (integration's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/integration.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/integration.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: integration-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/integration.gebo.ai/src/test/java/ai/gebo/microservices/integration/IntegrationContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/integration.gebo.ai/src/test/java/ai/gebo/microservices/integration/IntegrationContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
+
+/**
+ * integration actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation - this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, IntegrationApplication's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as
+ * an ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter}
+ * ordering for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration).
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { IntegrationApplication.class, IntegrationContextTest.DiscoveryStubConfig.class })
+class IntegrationContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("integration-home");
+			Path work = Files.createTempDirectory("integration-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the integration test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: integration owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** integration's own content-handler surface still comes up alongside all of the above. */
+	@Test
+	void publishesItsOwnContentHandler() {
+		assertThat(context.getBeansOfType(IGContentManagementSystemHandler.class)).isNotEmpty();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/jira.gebo.ai/src/main/java/ai/gebo/microservices/jira/JiraApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/jira.gebo.ai/src/main/java/ai/gebo/microservices/jira/JiraApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.jira;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (jira's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/jira.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/jira.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: jira-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/jira.gebo.ai/src/test/java/ai/gebo/microservices/jira/JiraContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/jira.gebo.ai/src/test/java/ai/gebo/microservices/jira/JiraContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.jira;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
+
+/**
+ * jira actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation - this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, JiraApplication's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as
+ * an ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter}
+ * ordering for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration).
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { JiraApplication.class, JiraContextTest.DiscoveryStubConfig.class })
+class JiraContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("jira-home");
+			Path work = Files.createTempDirectory("jira-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the jira test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: jira owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** jira's own content-handler surface still comes up alongside all of the above. */
+	@Test
+	void publishesItsOwnContentHandler() {
+		assertThat(context.getBeansOfType(IGContentManagementSystemHandler.class)).isNotEmpty();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/mcpclient.gebo.ai/src/main/java/ai/gebo/microservices/mcpclient/McpClientApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/mcpclient.gebo.ai/src/main/java/ai/gebo/microservices/mcpclient/McpClientApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.mcpclient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (mcpclient's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/mcpclient.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/mcpclient.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: mcpclient-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/mcpclient.gebo.ai/src/test/java/ai/gebo/microservices/mcpclient/McpClientContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/mcpclient.gebo.ai/src/test/java/ai/gebo/microservices/mcpclient/McpClientContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.mcpclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
+
+/**
+ * mcpclient actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation - this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, McpClientApplication's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as
+ * an ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter}
+ * ordering for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration).
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { McpClientApplication.class, McpClientContextTest.DiscoveryStubConfig.class })
+class McpClientContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("mcpclient-home");
+			Path work = Files.createTempDirectory("mcpclient-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the mcpclient test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: mcpclient owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** mcpclient's own content-handler surface still comes up alongside all of the above. */
+	@Test
+	void publishesItsOwnContentHandler() {
+		assertThat(context.getBeansOfType(IGContentManagementSystemHandler.class)).isNotEmpty();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/pom.xml
@@ -60,6 +60,24 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
+		<!-- Shared by every microservice's <Service>ContextTest (see heimdall.gebo.ai's
+		     HeimdallContextTest for the pattern): boots the real Application class against
+		     a Mongo testcontainer with a stubbed DiscoveryClient, in place of Eureka. -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers-mongodb</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/sharepoint.gebo.ai/src/main/java/ai/gebo/microservices/sharepoint/SharepointApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/sharepoint.gebo.ai/src/main/java/ai/gebo/microservices/sharepoint/SharepointApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.sharepoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (sharepoint's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/sharepoint.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/sharepoint.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: sharepoint-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/sharepoint.gebo.ai/src/test/java/ai/gebo/microservices/sharepoint/SharepointContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/sharepoint.gebo.ai/src/test/java/ai/gebo/microservices/sharepoint/SharepointContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.sharepoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
+
+/**
+ * sharepoint actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation - this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, SharepointApplication's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as
+ * an ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter}
+ * ordering for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration).
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { SharepointApplication.class, SharepointContextTest.DiscoveryStubConfig.class })
+class SharepointContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("sharepoint-home");
+			Path work = Files.createTempDirectory("sharepoint-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the sharepoint test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: sharepoint owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** sharepoint's own content-handler surface still comes up alongside all of the above. */
+	@Test
+	void publishesItsOwnContentHandler() {
+		assertThat(context.getBeansOfType(IGContentManagementSystemHandler.class)).isNotEmpty();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/tyr.gebo.ai/src/main/java/ai/gebo/microservices/tyr/TyrApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/tyr.gebo.ai/src/main/java/ai/gebo/microservices/tyr/TyrApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.tyr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -32,7 +35,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (tyr's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/tyr.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/tyr.gebo.ai/src/main/resources/application.yml
@@ -16,3 +16,14 @@ eureka:
     virtual-host-name: tyr-gebo-ai
     secure-virtual-host-name: tyr-gebo-ai
     prefer-ip-address: true
+
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/tyr.gebo.ai/src/test/java/ai/gebo/microservices/tyr/TyrContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/tyr.gebo.ai/src/test/java/ai/gebo/microservices/tyr/TyrContextTest.java
@@ -1,0 +1,149 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.tyr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.microservices.workflow.steps.IWorkflowParticipantsEnablementResolver;
+import ai.gebo.microservices.globaltopology.service.IGGlobalInternalTopologyService;
+import ai.gebo.microservices.globaltopology.service.impl.GGlobalInternalTopologyServiceImpl;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+
+/**
+ * tyr actually starts, and it resolves the secrets/security/ACL directories
+ * through the REMOTE (heimdall) clients rather than any local implementation,
+ * plus the workflow-step enablement authority and the global internal topology
+ * service that are tyr's own reason to exist.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, {@code TyrApplication}'s
+ * {@code @ComponentScan(basePackages = "ai.gebo")} drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated, which would silently defeat {@code @AutoConfigureAfter} ordering for
+ * the client auto-configurations this service depends on.
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { TyrApplication.class, TyrContextTest.DiscoveryStubConfig.class })
+class TyrContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("tyr-home");
+			Path work = Files.createTempDirectory("tyr-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the tyr test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: tyr owns none of secrets, the security
+	 * directory or the ACL store, so all three must resolve to their REST client
+	 * implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** tyr is the workflow-step enablement authority - this must actually publish. */
+	@Test
+	void publishesWorkflowStepEnablementAuthority() {
+		assertThat(context.getBean(IWorkflowParticipantsEnablementResolver.class)).isNotNull();
+	}
+
+	/** The global internal topology service tyr owns (polled by every other service). */
+	@Test
+	void ownsTheGlobalInternalTopologyService() {
+		assertThat(context.getBean(IGGlobalInternalTopologyService.class))
+				.isInstanceOf(GGlobalInternalTopologyServiceImpl.class);
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/uploads.gebo.ai/src/main/java/ai/gebo/microservices/uploads/UploadsApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/uploads.gebo.ai/src/main/java/ai/gebo/microservices/uploads/UploadsApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.uploads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (uploads's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/uploads.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/uploads.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: uploads-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/uploads.gebo.ai/src/test/java/ai/gebo/microservices/uploads/UploadsContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/uploads.gebo.ai/src/test/java/ai/gebo/microservices/uploads/UploadsContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.uploads;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
+
+/**
+ * uploads actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation - this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, UploadsApplication's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as
+ * an ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter}
+ * ordering for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration).
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { UploadsApplication.class, UploadsContextTest.DiscoveryStubConfig.class })
+class UploadsContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("uploads-home");
+			Path work = Files.createTempDirectory("uploads-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the uploads test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: uploads owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** uploads's own content-handler surface still comes up alongside all of the above. */
+	@Test
+	void publishesItsOwnContentHandler() {
+		assertThat(context.getBeansOfType(IGContentManagementSystemHandler.class)).isNotEmpty();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/userspace.gebo.ai/src/main/java/ai/gebo/microservices/userspace/UserspaceApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/userspace.gebo.ai/src/main/java/ai/gebo/microservices/userspace/UserspaceApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.userspace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,7 +36,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (userspace's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/userspace.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/userspace.gebo.ai/src/main/resources/application.yml
@@ -35,6 +35,18 @@ eureka:
     secure-virtual-host-name: userspace-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/userspace.gebo.ai/src/test/java/ai/gebo/microservices/userspace/UserspaceContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/userspace.gebo.ai/src/test/java/ai/gebo/microservices/userspace/UserspaceContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.userspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+import ai.gebo.systems.abstraction.layer.IGContentManagementSystemHandler;
+
+/**
+ * userspace actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation - this service owns none of the three stores.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, UserspaceApplication's {@code Application} class
+ * restates {@code @ComponentScan(basePackages = "ai.gebo")} directly, which drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated. Without {@code AutoConfigurationExcludeFilter}, component-scanning
+ * would pick up every {@code @AutoConfiguration} class under {@code ai.gebo} as
+ * an ordinary bean, in classpath order, defeating {@code @AutoConfigureAfter}
+ * ordering for the client auto-configurations this service depends on
+ * (secrets/security/acl.client, both requiring {@code GeboMicroserviceUrlResolver}
+ * from the topology auto-configuration).
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { UserspaceApplication.class, UserspaceContextTest.DiscoveryStubConfig.class })
+class UserspaceContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("userspace-home");
+			Path work = Files.createTempDirectory("userspace-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the userspace test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: userspace owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/** userspace's own content-handler surface still comes up alongside all of the above. */
+	@Test
+	void publishesItsOwnContentHandler() {
+		assertThat(context.getBeansOfType(IGContentManagementSystemHandler.class)).isNotEmpty();
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.apps.parent/gebo.microservices.apps.parent/vectorizator.gebo.ai/src/main/java/ai/gebo/microservices/vectorizator/VectorizatorApplication.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/vectorizator.gebo.ai/src/main/java/ai/gebo/microservices/vectorizator/VectorizatorApplication.java
@@ -12,9 +12,12 @@ package ai.gebo.microservices.vectorizator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -34,7 +37,20 @@ import ai.gebo.architecture.environment.EnvironmentHolder;
  * </p>
  */
 @SpringBootApplication
-@ComponentScan(basePackages = "ai.gebo")
+// basePackages is widened to "ai.gebo" (vectorizator's own production beans live
+// outside its microservice-specific package), but @ComponentScan given DIRECTLY on
+// the class replaces - rather than merges with - the one @SpringBootApplication
+// supplies, so its default excludeFilters (TypeExcludeFilter,
+// AutoConfigurationExcludeFilter) are lost unless restated here. Without
+// AutoConfigurationExcludeFilter, plain component-scanning picks up every
+// @AutoConfiguration class under "ai.gebo" (they are @Configuration too) as an
+// ordinary bean, processed in classpath-scan order rather than through
+// @EnableAutoConfiguration's deferred, @AutoConfigureAfter/Before-sorted import -
+// silently defeating that ordering for the cluster/client auto-configurations this
+// service depends on.
+@ComponentScan(basePackages = "ai.gebo",
+		excludeFilters = { @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+				@ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class) })
 @EnableConfigurationProperties
 @EnableAsync
 @EnableScheduling

--- a/gebo.apps.parent/gebo.microservices.apps.parent/vectorizator.gebo.ai/src/main/resources/application.yml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/vectorizator.gebo.ai/src/main/resources/application.yml
@@ -37,6 +37,18 @@ eureka:
     secure-virtual-host-name: vectorizator-gebo-ai
     prefer-ip-address: true
 
+# gebo.architecture.security's WebMvcConfig is on every microservice's classpath
+# (pulled in transitively for IGeboSystemUserService/crypting), so this property
+# must resolve even though this service has no AuthController of its own. In the
+# docker stack the shared config overlay supplies the real value; this is the
+# standalone default.
+ai:
+  gebo:
+    security:
+      cors:
+        allowedOrigins: ${GEBO_CORS_ALLOWED_ORIGINS:http://localhost:13000,http://localhost:4200}
+
+
 # ---------------------------------------------------------------------------
 # MongoDB database. The SERVER (host, credentials) comes from the shared config;
 # the DATABASE is chosen here, per service.

--- a/gebo.apps.parent/gebo.microservices.apps.parent/vectorizator.gebo.ai/src/test/java/ai/gebo/microservices/vectorizator/VectorizatorContextTest.java
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/vectorizator.gebo.ai/src/test/java/ai/gebo/microservices/vectorizator/VectorizatorContextTest.java
@@ -1,0 +1,152 @@
+/**
+ * This Source Code is subject to the terms of the
+ * Gebo.ai community version Mozilla Public License Version 2.0 (MPL-2.0) — With Data Protection Clauses
+ * If a copy of the LICENCE was not distributed with this file, You can obtain one at
+ * https://gebo.ai/gebo-ai-community-version-mozilla-public-license-version-2-0-mpl-2-0-with-data-protection-clauses/
+ * and https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2025+ Gebo.ai
+ */
+
+package ai.gebo.microservices.vectorizator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.gebo.architecture.environment.EnvironmentHolder;
+import ai.gebo.microservices.acl.client.RestAclAliasesDao;
+import ai.gebo.microservices.security.client.RestSecurityDirectory;
+import ai.gebo.microservices.secrets.client.GeboSecretsAccessServiceRestClient;
+import ai.gebo.microservices.topology.GeboMicroserviceUrlResolver;
+import ai.gebo.microservices.models.replication.DiscoveryClientClusterTopologyProvider;
+import ai.gebo.architecture.hazelcast.IGModelsReplicationClusterTopologyProvider;
+import ai.gebo.acl.IAclAliasesDao;
+import ai.gebo.security.services.IGSecurityDirectory;
+import ai.gebo.secrets.services.IGeboSecretsAccessService;
+
+/**
+ * vectorizator actually starts, and it resolves the secrets/security/ACL
+ * directories through the REMOTE (heimdall) clients rather than any local
+ * implementation, and correctly seeds its models-replication cache membership
+ * from LIVE discovery rather than the static-name fallback.
+ *
+ * <h2>Why this test exists</h2>
+ * <p>
+ * Like every non-heimdall microservice, VectorizatorApplication's
+ * {@code @ComponentScan(basePackages = "ai.gebo")} drops
+ * {@code @SpringBootApplication}'s default exclude filters unless explicitly
+ * reinstated, which would silently defeat {@code @AutoConfigureAfter} ordering.
+ * vectorizator is the clearest case: its own
+ * {@code ModelsReplicationClusterAutoConfiguration} publishes the
+ * discovery-backed {@code IGModelsReplicationClusterTopologyProvider} only
+ * {@code @ConditionalOnBean(DiscoveryClient.class)} - exactly the pattern that
+ * silently produced the WRONG (name-based fallback) provider in heimdall before
+ * the fix, with no error, just a less-accurate cluster view.
+ * </p>
+ *
+ * Gebo.ai comment agent
+ */
+@Testcontainers
+@SpringBootTest(classes = { VectorizatorApplication.class, VectorizatorContextTest.DiscoveryStubConfig.class })
+class VectorizatorContextTest {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+	static {
+		try {
+			Path home = Files.createTempDirectory("vectorizator-home");
+			Path work = Files.createTempDirectory("vectorizator-work");
+			System.setProperty(EnvironmentHolder.GEBO_HOME, home.toAbsolutePath().toString());
+			System.setProperty(EnvironmentHolder.GEBO_WORK_DIRECTORY, work.toAbsolutePath().toString());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot prepare the vectorizator test home", e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.mongodb.host", mongo::getHost);
+		registry.add("spring.data.mongodb.port", mongo::getFirstMappedPort);
+		registry.add("ai.gebo.mongodb.enabled", () -> true);
+		registry.add("ai.gebo.mongodb.connectionString", mongo::getConnectionString);
+		registry.add("eureka.client.enabled", () -> false);
+		registry.add("eureka.client.register-with-eureka", () -> false);
+		registry.add("eureka.client.fetch-registry", () -> false);
+	}
+
+	@Autowired
+	ApplicationContext context;
+
+	/**
+	 * The remote directory/store clients: vectorizator owns none of secrets, the
+	 * security directory or the ACL store, so all three must resolve to their REST
+	 * client implementation, never a local one it has no business creating.
+	 */
+	@Test
+	void resolvesRemoteClusterClients() {
+		assertThat(context.getBean(IGeboSecretsAccessService.class))
+				.isInstanceOf(GeboSecretsAccessServiceRestClient.class);
+		assertThat(context.getBean(IGSecurityDirectory.class)).isInstanceOf(RestSecurityDirectory.class);
+		assertThat(context.getBean(IAclAliasesDao.class)).isInstanceOf(RestAclAliasesDao.class);
+	}
+
+	/** The topology url resolver these clients depend on for ordering. */
+	@Test
+	void publishesTheUrlResolver() {
+		assertThat(context.getBean(GeboMicroserviceUrlResolver.class)).isNotNull();
+	}
+
+	/**
+	 * vectorizator is a default models-replication participant, and a
+	 * {@link DiscoveryClient} is available (a stub here, Eureka's in production),
+	 * so the topology provider must be the discovery-backed one - never the
+	 * static-name fallback that only exists for a deployment with no discovery.
+	 */
+	@Test
+	void seedsModelsReplicationFromLiveDiscovery() {
+		assertThat(context.getBean(IGModelsReplicationClusterTopologyProvider.class))
+				.isInstanceOf(DiscoveryClientClusterTopologyProvider.class);
+	}
+
+	@TestConfiguration
+	static class DiscoveryStubConfig {
+
+		@Bean
+		DiscoveryClient discoveryClient() {
+			return new DiscoveryClient() {
+
+				@Override
+				public String description() {
+					return "test";
+				}
+
+				@Override
+				public List<String> getServices() {
+					return List.of();
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId) {
+					return List.of();
+				}
+			};
+		}
+	}
+}

--- a/gebo.architecture.parent/gebo.security.directory.mongo/src/main/java/ai/gebo/security/directory/mongo/config/GeboMongoSecurityDirectoryAutoConfiguration.java
+++ b/gebo.architecture.parent/gebo.security.directory.mongo/src/main/java/ai/gebo/security/directory/mongo/config/GeboMongoSecurityDirectoryAutoConfiguration.java
@@ -42,9 +42,17 @@ import ai.gebo.security.services.IGeboSystemUserService;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class GeboMongoSecurityDirectoryAutoConfiguration {
 
+	// Declared to return the CONCRETE type, not IGSecurityDirectory: consumers that
+	// @Autowire/@ConditionalOnMissingBean the interface still resolve it fine (Spring
+	// matches subtypes to a requested supertype), but GeboSecurityClusterControllerAutoConfiguration's
+	// @ConditionalOnBean(MongoSecurityDirectory.class) - "publish only if this service
+	// OWNS the directory, not merely sees the interface" - can only ever match a bean
+	// whose declared/factory-method type is that concrete class; a bean typed as the
+	// interface is invisible to a @ConditionalOnBean asking for one of its subtypes,
+	// regardless of @AutoConfigureAfter ordering between the two.
 	@Bean
 	@ConditionalOnMissingBean(IGSecurityDirectory.class)
-	public IGSecurityDirectory mongoSecurityDirectory(UserRepository usersRepo, UsersGroupRepository groupsRepo,
+	public MongoSecurityDirectory mongoSecurityDirectory(UserRepository usersRepo, UsersGroupRepository groupsRepo,
 			PasswordEncoder passwordEncoder, IGeboSystemUserService systemUserService) {
 		return new MongoSecurityDirectory(usersRepo, groupsRepo, passwordEncoder, systemUserService);
 	}

--- a/gebo.microservices.architecture.parent/gebo.microservices.cluster.commons/src/main/java/ai/gebo/microservices/cluster/config/GeboClusterCommonsAutoConfiguration.java
+++ b/gebo.microservices.architecture.parent/gebo.microservices.cluster.commons/src/main/java/ai/gebo/microservices/cluster/config/GeboClusterCommonsAutoConfiguration.java
@@ -15,7 +15,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.client.CommonsClientAutoConfiguration;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClientAutoConfiguration;
+import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 
 import ai.gebo.microservices.cluster.GeboClusterParticipants;
@@ -31,7 +34,8 @@ import ai.gebo.security.services.IGeboSystemUserService;
  *
  * Gebo.ai comment agent
  */
-@AutoConfiguration(after = GeboMicroservicesTopologyAutoConfiguration.class)
+@AutoConfiguration(after = { GeboMicroservicesTopologyAutoConfiguration.class, SimpleDiscoveryClientAutoConfiguration.class,
+		CompositeDiscoveryClientAutoConfiguration.class, CommonsClientAutoConfiguration.class })
 @EnableConfigurationProperties(GeboClusterParticipantsProperties.class)
 public class GeboClusterCommonsAutoConfiguration {
 
@@ -40,6 +44,15 @@ public class GeboClusterCommonsAutoConfiguration {
 	 * Requires a {@link DiscoveryClient}: membership must be <i>discovered</i>, never
 	 * merely configured. Absent one, no participants bean exists and the guards that
 	 * depend on it never register - so their controllers do not either.
+	 *
+	 * <p>
+	 * The class-level {@code after} above is load-bearing: without it, this
+	 * auto-configuration can sort before the ones that actually publish a
+	 * {@link DiscoveryClient} bean, so {@code @ConditionalOnBean(DiscoveryClient.class)}
+	 * finds nothing even when one is registered (a stub in tests, Eureka's in
+	 * production) - silently skipping this bean and every cluster surface downstream
+	 * of it.
+	 * </p>
 	 */
 	@Bean
 	@ConditionalOnClass(DiscoveryClient.class)

--- a/gebo.microservices.architecture.parent/gebo.microservices.security.controller/src/main/java/ai/gebo/microservices/security/config/GeboSecurityClusterControllerAutoConfiguration.java
+++ b/gebo.microservices.architecture.parent/gebo.microservices.security.controller/src/main/java/ai/gebo/microservices/security/config/GeboSecurityClusterControllerAutoConfiguration.java
@@ -24,6 +24,7 @@ import ai.gebo.microservices.cluster.GeboClusterParticipants;
 import ai.gebo.microservices.cluster.config.GeboClusterCommonsAutoConfiguration;
 import ai.gebo.microservices.security.controller.SecurityDirectoryClusterController;
 import ai.gebo.security.directory.mongo.MongoSecurityDirectory;
+import ai.gebo.security.directory.mongo.config.GeboMongoSecurityDirectoryAutoConfiguration;
 import ai.gebo.security.services.IGSecurityDirectory;
 
 /**
@@ -49,9 +50,19 @@ import ai.gebo.security.services.IGSecurityDirectory;
  * this class installs alongside it.
  * </p>
  *
+ * <p>
+ * {@code after} names both producers this class is {@code @ConditionalOnBean} on:
+ * {@link MongoSecurityDirectory} comes from
+ * {@link GeboMongoSecurityDirectoryAutoConfiguration}, a separate auto-configuration
+ * (not a plain {@code @Component}), so without this ordering the
+ * {@code AutoConfigurationSorter} has no constraint between the two and may run this
+ * class first - the condition would then find no bean and never look again.
+ * </p>
+ *
  * Gebo.ai comment agent
  */
-@AutoConfiguration(after = GeboClusterCommonsAutoConfiguration.class)
+@AutoConfiguration(
+		after = { GeboClusterCommonsAutoConfiguration.class, GeboMongoSecurityDirectoryAutoConfiguration.class })
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @ConditionalOnBean({ MongoSecurityDirectory.class, GeboClusterParticipants.class })
 @ConditionalOnProperty(prefix = "ai.gebo.security.cluster", name = "enabled", havingValue = "true",

--- a/gebo.ui/package-lock.json
+++ b/gebo.ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-ui",
-  "version": "1.0.2.0-SNAPSHOT",
+  "version": "1.0.2.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-ui",
-      "version": "1.0.2.0-SNAPSHOT",
+      "version": "1.0.2.1-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/cdk": "^21.2.14",

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,15 @@
 								<groupId>org.projectlombok</groupId>
 								<artifactId>lombok</artifactId>
 							</path>
+							<!-- Generates META-INF/spring-autoconfigure-metadata.properties, which
+							     AutoConfigurationSorter reads to honour @AutoConfigureAfter/@AutoConfigureBefore.
+							     Explicit annotationProcessorPaths (added above for lombok) disables Maven's
+							     automatic classpath-based processor discovery, so without this entry every
+							     such annotation in the codebase is silently ignored. -->
+							<path>
+								<groupId>org.springframework.boot</groupId>
+								<artifactId>spring-boot-autoconfigure-processor</artifactId>
+							</path>
 						</annotationProcessorPaths>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
## Summary
- Every microservice `Application` class restated `@ComponentScan(basePackages = "ai.gebo")` directly, which silently drops `@SpringBootApplication`'s default exclude filters (`TypeExcludeFilter`, `AutoConfigurationExcludeFilter`). Without `AutoConfigurationExcludeFilter`, component-scanning picked up every `@AutoConfiguration` class under `ai.gebo` as an ordinary bean in raw classpath order, bypassing `@EnableAutoConfiguration`'s deferred, `@AutoConfigureAfter`-sorted import - silently defeating that ordering for the cluster/client auto-configurations that depend on it (`GeboClusterParticipants`, the secrets/security/acl client wiring, models-replication topology providers). Fixed by restoring both exclude filters on all 18 microservice `Application` classes.
- The root `pom.xml`'s `maven-compiler-plugin` had an explicit Lombok-only `annotationProcessorPaths`, which disables Maven's automatic classpath-based annotation-processor discovery repo-wide. `spring-boot-autoconfigure-processor` was never in that list, so **no** `@AutoConfigureAfter`/`@AutoConfigureBefore` anywhere in the codebase was ever actually honoured. Added it.
- `gebo.architecture.security`'s `WebMvcConfig` is transitively on every microservice's classpath, so `ai.gebo.security.cors.allowedOrigins` must resolve even for services with no `AuthController` of their own - otherwise the context fails to start outside the docker-compose overlay that normally supplies it. Added a sane default to all 18 microservices' `application.yml`.
- `GeboMongoSecurityDirectoryAutoConfiguration`: declared the bean's concrete `MongoSecurityDirectory` return type instead of the `IGSecurityDirectory` interface, so `GeboSecurityClusterControllerAutoConfiguration`'s `@ConditionalOnBean(MongoSecurityDirectory.class)` can actually see it.
- `GeboSecurityClusterControllerAutoConfiguration` / `GeboClusterCommonsAutoConfiguration`: added the missing `@AutoConfigureAfter` producers.
- Added a `<Service>ContextTest` for every one of the 19 microservice apps (heimdall already had one). Each boots the real `Application` class against a Mongo testcontainer with a stubbed `DiscoveryClient` in place of Eureka, asserting the secrets/security/acl directories resolve to their REMOTE client implementation rather than a local one. `brain`/`vectorizator`/`graphicator` also assert the models-replication topology provider resolves to the discovery-backed implementation rather than the static-name fallback - the same `@ConditionalOnBean(DiscoveryClient.class)` pattern that silently broke in heimdall before this fix.

## Test plan
- [x] `heimdall.gebo.ai`: 4/4 tests pass with the original, unmodified test file
- [x] All 17 new `<Service>ContextTest` files pass
- [x] Full root `mvn clean install`: 168/168 modules, monolith (`gebo.ai.app`) unaffected
- [x] Full `gebo.microservices.apps.parent` build: all 19 apps together, `BUILD SUCCESS`