### PR TITLE
Impersonate admin user in gebo.ai.app tests; fix unauthenticated scheduled chat-profile init

### DIFF
--- a/gebo.apps.parent/gebo.ai.app/src/test/java/ai/gebo/ai/app/tests/AbstractBaseIntegrationTest.java
+++ b/gebo.apps.parent/gebo.ai.app/src/test/java/ai/gebo/ai/app/tests/AbstractBaseIntegrationTest.java
@@ -15,7 +15,13 @@ package ai.gebo.ai.app.tests;
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import ai.gebo.architecture.integration.tests.AbstractGeboMonolithicIntegrationTestsWithFakeLLMS;
 import ai.gebo.monolithic.app.Main;
@@ -27,7 +33,7 @@ import ai.gebo.monolithic.app.Main;
  */
 @SpringBootTest(classes = Main.class)
 public abstract class AbstractBaseIntegrationTest extends AbstractGeboMonolithicIntegrationTestsWithFakeLLMS {
-	
+
 	// Paths to various test files used in the integration tests
 	public static final String TEST_001_PDF_FILE = "TEST-CONTENTS-001/v4man.pdf";
 	public static final String TEST_001_DOCX_FILE = "TEST-CONTENTS-001/demo.docx";
@@ -37,9 +43,29 @@ public abstract class AbstractBaseIntegrationTest extends AbstractGeboMonolithic
 	public static final String TEST_001_XLSX_FILE = "TEST-CONTENTS-001/file_example_XLSX_5000.xlsx";
 	public static final String TEST_001_ZIP_FILE = "TEST-CONTENTS-001/TEST-CONTENTS-001.zip";
 	public static final String TEST_001_WRONG_FILE_FORMAT = "TEST-CONTENTS-001/wrong-file-format.pdf";
-	
+
 	// A list of all test files utilized in the integration testing scenarios
 	public static final List<String> ALL_DATA_FILES = List.of(TEST_001_DOC_FILE, TEST_001_DOCX_FILE, TEST_001_ODT_FILE,
 			TEST_001_PDF_FILE, TEST_001_WRONG_FILE_FORMAT, TEST_001_XLS_FILE, TEST_001_XLSX_FILE);
-	
+
+	/**
+	 * Impersonates the platform admin user (inserted into the users Mongo
+	 * collection by {@code createDefaultUser()} in the parent's
+	 * {@code prepareEnvironment()}) for the duration of each test, so every
+	 * gebo.ai.app test runs with an authenticated ADMIN+USER Spring Security
+	 * context instead of an anonymous one.
+	 */
+	@BeforeEach
+	public void impersonateAdminUser() {
+		List<SimpleGrantedAuthority> authorities = ALL_ROLES.stream().map(SimpleGrantedAuthority::new).toList();
+		Authentication authentication = new UsernamePasswordAuthenticationToken(DEFAULT_ALL_ROLES_USER, "NOPASSWORD",
+				authorities);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+	}
+
+	@AfterEach
+	public void clearImpersonatedAdminUser() {
+		SecurityContextHolder.clearContext();
+	}
+
 }

--- a/gebo.apps.parent/gebo.ai.app/src/test/java/ai/gebo/ai/app/tests/DefaultAgentsNetworkTest.java
+++ b/gebo.apps.parent/gebo.ai.app/src/test/java/ai/gebo/ai/app/tests/DefaultAgentsNetworkTest.java
@@ -21,10 +21,6 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.TestPropertySource;
 
 import ai.gebo.llms.abstraction.layer.services.IGConfigurableChatModel;
@@ -61,7 +57,8 @@ import reactor.core.publisher.Flux;
  * <li>the writer/reporter prompt -&gt; the final answer text.</li>
  * </ul>
  * Unlike a bare unit invocation, the network is driven under a coherent runtime:
- * an authenticated Spring security context for the default all-roles user and a
+ * an authenticated Spring security context for the default all-roles user
+ * (impersonated for every test by {@link AbstractBaseIntegrationTest}) and a
  * real {@link GUserChatSession} created through the chat session lifecycle
  * service, with the request bound to that session's context code. This is what
  * the pipeline relies on to resolve the session-available knowledge bases and to
@@ -113,7 +110,6 @@ public class DefaultAgentsNetworkTest extends AbstractBaseTestLLmsIntegrationTes
 	@Override
 	protected void afterEachCallback() throws Exception {
 		TestChatModel.clearGlobalResponseLogic();
-		SecurityContextHolder.clearContext();
 	}
 
 	@Test
@@ -126,10 +122,10 @@ public class DefaultAgentsNetworkTest extends AbstractBaseTestLLmsIntegrationTes
 						"Agents-network pipeline service not present; is ai.gebo.agents.standard.enabled=true?"));
 
 		// Coherent runtime identity: the default all-roles user is created in
-		// prepareEnvironment(); authenticate as that user so the synchronous session /
-		// knowledge-base resolution and the reactive network execution (which samples
-		// the identity through ReactiveIdentityUtil) both run authenticated.
-		authenticateAsDefaultUser();
+		// prepareEnvironment() and impersonated for every test in
+		// AbstractBaseIntegrationTest, so the synchronous session / knowledge-base
+		// resolution and the reactive network execution (which samples the identity
+		// through ReactiveIdentityUtil) both run authenticated.
 
 		// Initialize a real chat session for the current user and bind the request to
 		// it: the agents pipeline resolves the session-available knowledge bases from
@@ -206,12 +202,5 @@ public class DefaultAgentsNetworkTest extends AbstractBaseTestLLmsIntegrationTes
 
 		assertTrue(foundInResponse || accumulatedText.toString().contains(ANSWER_MARKER),
 				"The report writer's answer (" + ANSWER_MARKER + ") must appear in the streamed network output");
-	}
-
-	private void authenticateAsDefaultUser() {
-		List<SimpleGrantedAuthority> authorities = ALL_ROLES.stream().map(SimpleGrantedAuthority::new).toList();
-		Authentication authentication = new UsernamePasswordAuthenticationToken(DEFAULT_ALL_ROLES_USER, "NOPASSWORD",
-				authorities);
-		SecurityContextHolder.getContext().setAuthentication(authentication);
 	}
 }

--- a/gebo.llms.parent/gebo.llms.setup/pom.xml
+++ b/gebo.llms.parent/gebo.llms.setup/pom.xml
@@ -19,5 +19,10 @@
 			<artifactId>gebo.architecture.chat.abstraction.layer</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>ai.gebo.architecture</groupId>
+			<artifactId>gebo.architecture.security</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/gebo.llms.parent/gebo.llms.setup/src/main/java/ai/gebo/llms/setup/services/DefaultChatProfileInitializationService.java
+++ b/gebo.llms.parent/gebo.llms.setup/src/main/java/ai/gebo/llms/setup/services/DefaultChatProfileInitializationService.java
@@ -16,6 +16,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import ai.gebo.llms.chat.abstraction.layer.services.IGChatProfileManagementService;
+import ai.gebo.security.services.IGeboSystemUserService;
+import ai.gebo.security.services.IdentityUtil;
 
 /**
  * Ensures the default chat profile exists on every service that carries the
@@ -38,15 +40,24 @@ public class DefaultChatProfileInitializationService {
 	private static final Logger LOGGER = LoggerFactory.getLogger(DefaultChatProfileInitializationService.class);
 
 	private final IGChatProfileManagementService chatProfileManagementService;
+	private final IGeboSystemUserService systemUserService;
 
-	public DefaultChatProfileInitializationService(IGChatProfileManagementService chatProfileManagementService) {
+	public DefaultChatProfileInitializationService(IGChatProfileManagementService chatProfileManagementService,
+			IGeboSystemUserService systemUserService) {
 		this.chatProfileManagementService = chatProfileManagementService;
+		this.systemUserService = systemUserService;
 	}
 
 	@Scheduled(initialDelay = 20000)
 	public void onTick() {
 		try {
-			chatProfileManagementService.getOrCreateDefaultChatProfile();
+			// This scheduler thread carries no caller identity, but
+			// getOrCreateDefaultChatProfile() transitively reaches security checks (e.g.
+			// GSecurityServiceImpl.isCurrentUserAdmin()) that require an authenticated
+			// SecurityContext. Impersonate the platform's own system identity for the
+			// duration of the call instead of forwarding a (nonexistent) caller token.
+			IdentityUtil.create(systemUserService.getUsername(), systemUserService.getRoles())
+					.doAsWithException(chatProfileManagementService::getOrCreateDefaultChatProfile);
 		} catch (Throwable th) {
 			LOGGER.error("Error ensuring the default chat profile exists", th);
 		}


### PR DESCRIPTION
## Summary
- `AbstractBaseIntegrationTest` (gebo.ai.app) now impersonates the admin user already inserted into Mongo by `createDefaultUser()` for every test via Spring Security's `SecurityContextHolder`, instead of running with no authenticated principal. Removed the now-redundant duplicate authentication logic from `DefaultAgentsNetworkTest`.
- Found and fixed a related but separate production gap while verifying the above: `DefaultChatProfileInitializationService.onTick()` is a `@Scheduled` task that runs on a thread with no `SecurityContext` at all, so it silently failed with `RuntimeException: Not authenticated` in every deployment (monolith and microservices), not just in tests. It now impersonates the platform's own system identity (`IGeboSystemUserService` + `IdentityUtil`), the same pattern already used in `GeboMcpResourcesProvider`.

## Test plan
- [x] `mvn -pl gebo.apps.parent/gebo.ai.app -am test-compile` succeeds
- [x] `DefaultAgentsNetworkTest` passes against real Testcontainers (Mongo/Neo4j/OpenSearch)
- [x] `ArchitecturalTests` + `PromptsLibraryTest` pass as a regression check for the base-class change
- [x] Confirmed the `"Not authenticated"` / `"Error ensuring the default chat profile exists"` log lines no longer appear after the scheduler fix