### PR TITLE
feat(docker): multiplatform (amd64+arm64) support for all 3 docker images

### DIFF
--- a/dockers/build-multiplatform.sh
+++ b/dockers/build-multiplatform.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# build-multiplatform.sh — Build gebo.ai Docker images for linux/amd64 + linux/arm64
+#
+# Usage:
+#   ./dockers/build-multiplatform.sh                    # build all 3 images
+#   ./dockers/build-multiplatform.sh platform           # build only the base platform image
+#   ./dockers/build-multiplatform.sh gebo.ai            # build only geboai/gebo.ai
+#   ./dockers/build-multiplatform.sh easyinstall        # build only geboai/easyinstall.gebo.ai
+#
+# Prerequisites:
+#   - docker buildx enabled (docker buildx create --use --name multiarch if needed)
+#   - To --push you need a Docker Hub account with push access to geboai/*
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="1.0.2.1-SNAPSHOT"
+PLATFORMS="linux/amd64,linux/arm64"
+JAR="$REPO_ROOT/gebo.apps.parent/gebo.ai.app/target/gebo.ai.app-${VERSION}-bootable.jar"
+SBOM="$REPO_ROOT/gebo.apps.parent/gebo.ai.app/target/classes/META-INF/sbom/application.cdx.json"
+
+# First positional arg = which image; default = all
+TARGET="${1:-all}"
+
+build_platform() {
+  echo "=== Building geboai/platform:2.5 (multiplatform: $PLATFORMS) ==="
+  docker buildx build \
+    --platform "$PLATFORMS" \
+    -t geboai/platform:2.5 \
+    --push \
+    "$REPO_ROOT/dockers/gebo.ai.platform"
+}
+
+build_gebo_ai() {
+  echo "=== Building geboai/gebo.ai (multiplatform: $PLATFORMS) ==="
+  # Copy artifacts into build context
+  cp "$JAR" "$REPO_ROOT/dockers/gebo.ai/"
+  cp "$SBOM" "$REPO_ROOT/dockers/gebo.ai/"
+  docker buildx build \
+    --platform "$PLATFORMS" \
+    -t geboai/gebo.ai \
+    -t geboai/gebo.ai:${VERSION} \
+    --push \
+    "$REPO_ROOT/dockers/gebo.ai"
+}
+
+build_easyinstall() {
+  echo "=== Building geboai/easyinstall.gebo.ai (multiplatform: $PLATFORMS) ==="
+  # Copy artifacts into build context
+  cp "$JAR" "$REPO_ROOT/dockers/easyinstall.gebo.ai/"
+  cp "$SBOM" "$REPO_ROOT/dockers/easyinstall.gebo.ai/"
+  docker buildx build \
+    --platform "$PLATFORMS" \
+    -t geboai/easyinstall.gebo.ai \
+    -t geboai/easyinstall.gebo.ai:${VERSION} \
+    --push \
+    "$REPO_ROOT/dockers/easyinstall.gebo.ai"
+}
+
+case "$TARGET" in
+  platform)    build_platform ;;
+  gebo.ai)     build_gebo_ai ;;
+  easyinstall) build_easyinstall ;;
+  all)
+    build_platform
+    build_gebo_ai
+    build_easyinstall
+    ;;
+  *)
+    echo "Unknown target: $TARGET (use: platform, gebo.ai, easyinstall, or all)"
+    exit 1
+    ;;
+esac
+
+echo "=== Done ==="

--- a/dockers/easyinstall.gebo.ai/Dockerfile
+++ b/dockers/easyinstall.gebo.ai/Dockerfile
@@ -62,9 +62,9 @@ RUN mkdir -p ${MONGO_DATA} /var/log/mongodb
 COPY mongod.conf /etc/mongod.conf                 
 COPY mongo-init.sh /bin/mongo-init.sh   
 
-RUN curl -L -o /tmp/qdrant.deb https://github.com/qdrant/qdrant/releases/download/v1.15.3/qdrant_1.15.3-1_amd64.deb 
-RUN apt-get update 
-RUN apt-get install -y  /tmp/qdrant.deb 
+RUN curl -L -o /tmp/qdrant.deb "https://github.com/qdrant/qdrant/releases/download/v1.15.3/qdrant_1.15.3-1_${TARGETARCH}.deb"
+RUN apt-get update
+RUN apt-get install -y  /tmp/qdrant.deb
 RUN rm -rf /var/lib/apt/lists/* /tmp/qdrant.deb && mkdir -p ${QDRANT_DIR} /var/log/qdrant
 RUN mkdir -p /etc/qdrant
 COPY qdrant-config.yaml ${QDRANT_CONFIG}
@@ -95,8 +95,10 @@ RUN rm -rf ${NEO4J_HOME}/data/dbms \
 # OpenSearch cannot run as root: create a dedicated user.
 RUN useradd --system --shell /usr/sbin/nologin --home-dir ${OPENSEARCH_HOME} opensearch
 RUN mkdir -p /var/log/opensearch
-RUN curl -L -o /tmp/opensearch.tar.gz \
-        https://artifacts.opensearch.org/releases/bundle/opensearch/${OPENSEARCH_VERSION}/opensearch-${OPENSEARCH_VERSION}-linux-x64.tar.gz \
+# Multiplatform: OpenSearch uses x64 for amd64 and arm64 for arm64.
+RUN OS_ARCH=$(case "$TARGETARCH" in amd64) echo "x64" ;; arm64) echo "arm64" ;; *) echo "x64" ;; esac) \
+    && curl -L -o /tmp/opensearch.tar.gz \
+        "https://artifacts.opensearch.org/releases/bundle/opensearch/${OPENSEARCH_VERSION}/opensearch-${OPENSEARCH_VERSION}-linux-${OS_ARCH}.tar.gz" \
     && tar -xzf /tmp/opensearch.tar.gz -C /opt \
     && rm /tmp/opensearch.tar.gz \
     && ln -sfn /opt/opensearch-${OPENSEARCH_VERSION} ${OPENSEARCH_HOME} \
@@ -109,9 +111,11 @@ COPY supervisord.conf /etc/supervisor/supervisord.conf
 RUN mkdir -p /opt/
 RUN mkdir -p /opt/java/
 WORKDIR /opt/java/
-RUN curl -L -o jdk-21_linux-x64_bin.tar.gz https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz \
-    && tar -xzf jdk-21_linux-x64_bin.tar.gz \
-    && rm jdk-21_linux-x64_bin.tar.gz \
+# Multiplatform: Oracle JDK uses x64 for amd64 and aarch64 for arm64.
+RUN JDK_ARCH=$(case "$TARGETARCH" in amd64) echo "x64" ;; arm64) echo "aarch64" ;; *) echo "x64" ;; esac) \
+    && curl -L -o jdk-21.tar.gz "https://download.oracle.com/java/21/latest/jdk-21_linux-${JDK_ARCH}_bin.tar.gz" \
+    && tar -xzf jdk-21.tar.gz \
+    && rm jdk-21.tar.gz \
     && ln -sfn "$(ls -d jdk-21.* | head -n1)" jdk-21
 ENV JAVA_HOME=/opt/java/jdk-21
 ENV PATH=$JAVA_HOME/bin:$PATH

--- a/dockers/gebo.ai.platform/Dockerfile
+++ b/dockers/gebo.ai.platform/Dockerfile
@@ -13,11 +13,15 @@ RUN apt-get update && apt-get install -y  \
     && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /opt/
 RUN mkdir -p /opt/java/
-RUN curl -L -o /opt/java/jdk-21_linux-x64_bin.tar.gz https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz
 WORKDIR /opt/java/
-RUN tar zxvfs jdk-21_linux-x64_bin.tar.gz
-RUN rm jdk-21_linux-x64_bin.tar.gz
-ENV JAVA_HOME=/opt/java/jdk-21.0.11
+# Multiplatform: TARGETARCH is set automatically by docker buildx (amd64 or arm64).
+# Oracle JDK uses x64 for amd64 and aarch64 for arm64.
+RUN ARCH=$(case "$TARGETARCH" in amd64) echo "x64" ;; arm64) echo "aarch64" ;; *) echo "x64" ;; esac) \
+    && curl -L -o jdk-21.tar.gz "https://download.oracle.com/java/21/latest/jdk-21_linux-${ARCH}_bin.tar.gz" \
+    && tar xzf jdk-21.tar.gz \
+    && rm jdk-21.tar.gz \
+    && ln -sfn "$(ls -d jdk-21.* | head -n1)" jdk-21
+ENV JAVA_HOME=/opt/java/jdk-21
 ENV PATH=$JAVA_HOME/bin:$PATH
 ENV JAVA_EXTRA_SECURITY_DIR=/opt/
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
## Summary

Makes all 3 Docker images buildable for linux/amd64 and linux/arm64 using docker buildx.

## Changes

### dockers/gebo.ai.platform/Dockerfile (base image)
- JDK download now selects x64/aarch64 based on TARGETARCH
- JAVA_HOME uses a symlink (ln -sfn) instead of hardcoded version jdk-21.0.11

### dockers/easyinstall.gebo.ai/Dockerfile
- Qdrant .deb: uses TARGETARCH directly (qdrant publishes amd64.deb and arm64.deb)
- OpenSearch tarball: selects linux-x64 vs linux-arm64 based on TARGETARCH
- JDK download: selects x64/aarch64 based on TARGETARCH
- MongoDB apt source already had arch=amd64,arm64 — no change needed
- Neo4j installed via apt — arch-agnostic, no change needed

### dockers/gebo.ai/Dockerfile
- No changes needed — just uses the base image and copies a jar

### dockers/build-multiplatform.sh (new)
Build script that runs docker buildx build --platform linux/amd64,linux/arm64 --push for all 3 images (or individual ones via argument).

## Usage

```bash
# Prerequisites: docker buildx enabled
docker buildx create --use --name multiarch

# Build all 3 and push to Docker Hub
./dockers/build-multiplatform.sh

# Or build just one
./dockers/build-multiplatform.sh platform
./dockers/build-multiplatform.sh gebo.ai
./dockers/build-multiplatform.sh easyinstall
```

Note: multiplatform builds require --push to a registry (Docker buildx cannot --load multiplatform images into the local daemon). The script uses --push by default.