### PR TITLE
fix(ui): resolve oversized AWS S3 icon and BlockUI lockup in file chooser

### DIFF
--- a/gebo.ui/projects/gebo-ai-admin-ui/src/lib/admin-ui/gebo-ai-standard-modules-injections.module.ts
+++ b/gebo.ui/projects/gebo-ai-admin-ui/src/lib/admin-ui/gebo-ai-standard-modules-injections.module.ts
@@ -677,7 +677,7 @@ const mcpClientModuleConfigurationBlock: GeboAIPluggableProjectEndpointModule = 
  */
 const awsS3ModuleConfigurationBlock: GeboAIPluggableProjectEndpointModule = {
     moduleId: AWS_S3_MODULE,
-    addProjectEndpointicon: "pi pi-amazon",
+    addProjectEndpointicon: "pi pi-aws-s3",
     addProjectEndpointLabel: "+AWS S3",
     addProjectEndpointTitle: "add an AWS S3 (or S3-compatible) bucket data source",
     projecteEndpointClassName: "ai.gebo.awss3.content.handler.GAwsS3ProjectEndpoint",

--- a/gebo.ui/projects/gebo-ai-reusable-ui/src/lib/controls/choose-documents-panel/search-documents.component.ts
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/src/lib/controls/choose-documents-panel/search-documents.component.ts
@@ -22,7 +22,7 @@ import { Component, EventEmitter, forwardRef, Input, OnChanges, OnInit, Output, 
 import { FormControl, FormGroup, NG_VALUE_ACCESSOR } from "@angular/forms";
 import { BrowseParam, DocumentReferenceView, SearchDocumentByNameParam, SemanticQueryParam, UserKnowledgeBaseBrowsingControllerService, VFilesystemReference, VirtualFilesystemNavigationTreeStatus } from "@Gebo.ai/gebo-ai-rest-api";
 
-import { of } from "rxjs";
+import { finalize, of } from "rxjs";
 import { EnrichedDocumentReferenceView, EnrichedDocumentReferenceViewRetrieveService } from "../content-viewer/enriched-document-reference-view.service";
 import { browsePathObservableCallback, loadRootsObservableCallback, reconstructNavigationObservableCallback } from "../vfilesystem-selector/vfilesystem-types";
 import { IOperationStatus } from "../base-entity-editing-component/operation-status";
@@ -166,13 +166,12 @@ export class GeboAISearchDocumentsComponent implements OnInit, OnChanges, GeboAI
     private retrieveMainPanelDocsMetaData(): void {
         if (this.internalValue && this.internalValue.length) {
             this.loadingDocuments = true;
-            this.enrichedDocumentsMetaInfosService.findDocumentReferenceViewByCode(this.internalValue).subscribe({
+            this.enrichedDocumentsMetaInfosService.findDocumentReferenceViewByCode(this.internalValue).pipe(
+                finalize(() => { this.loadingDocuments = false; })
+            ).subscribe({
                 next: (docs) => {
                     this.outputDocuments = docs;
                     this.addSourceDocuments(docs);
-                },
-                complete: () => {
-                    this.loadingDocuments = false;
                 }
             });
         } else {
@@ -244,13 +243,12 @@ export class GeboAISearchDocumentsComponent implements OnInit, OnChanges, GeboAI
                         return outValue;
                     }).filter(x => x);
                     this.loadingDocuments = true;
-                    this.enrichedDocumentsMetaInfosService.findDocumentReferenceViewByCode(filesList).subscribe({
+                    this.enrichedDocumentsMetaInfosService.findDocumentReferenceViewByCode(filesList).pipe(
+                        finalize(() => { this.loadingDocuments = false; })
+                    ).subscribe({
                         next: (documentList) => {
                             this.browsingResultsDocuments = documentList;
                             this.addSourceDocuments(this.browsingResultsDocuments);
-                        },
-                        complete: () => {
-                            this.loadingDocuments = false;
                         }
                     });
                 }
@@ -261,13 +259,12 @@ export class GeboAISearchDocumentsComponent implements OnInit, OnChanges, GeboAI
             {
                 next: (filesList: string[]) => {
                     this.loadingDocuments = true;
-                    this.enrichedDocumentsMetaInfosService.findDocumentReferenceViewByCode(filesList).subscribe({
+                    this.enrichedDocumentsMetaInfosService.findDocumentReferenceViewByCode(filesList).pipe(
+                        finalize(() => { this.loadingDocuments = false; })
+                    ).subscribe({
                         next: (documentList) => {
                             this.userspaceResultsDocuments = documentList;
                             this.addSourceDocuments(this.userspaceResultsDocuments);
-                        },
-                        complete: () => {
-                            this.loadingDocuments = false;
                         }
                     });
                 }
@@ -306,23 +303,19 @@ export class GeboAISearchDocumentsComponent implements OnInit, OnChanges, GeboAI
         const fgValue: SemanticQueryParam = this.semanticSearchFormGroup.value;
         if (fgValue.query && fgValue.knowledgeBaseCodes) {
             this.runningSemanticSearch = true;
-            this.enrichedDocumentsMetaInfosService.semanticSearch(fgValue).subscribe({
+            this.enrichedDocumentsMetaInfosService.semanticSearch(fgValue).pipe(
+                finalize(() => { this.runningSemanticSearch = false; })
+            ).subscribe({
                 next: (values) => {
                     this.loadingDocuments = true;
-                    this.enrichedDocumentsMetaInfosService.findDocumentReferenceViewByCode(values).subscribe({
+                    this.enrichedDocumentsMetaInfosService.findDocumentReferenceViewByCode(values).pipe(
+                        finalize(() => { this.loadingDocuments = false; })
+                    ).subscribe({
                         next: (documentList) => {
                             this.semanticSearchResultsDocuments = documentList;
                             this.addSourceDocuments(this.semanticSearchResultsDocuments);
-                        },
-                        complete: () => {
-                            this.loadingDocuments = false;
                         }
                     });
-
-
-                },
-                complete: () => {
-                    this.runningSemanticSearch = false;
                 }
             });
         }
@@ -345,14 +338,13 @@ export class GeboAISearchDocumentsComponent implements OnInit, OnChanges, GeboAI
     doSearchByFileName() {
         const param: SearchDocumentByNameParam = this.fileNameSearchFormGroup.value;
         this.runningFileNameSearch = true;
-        this.enrichedDocumentsMetaInfosService.searchByDocumentName(param).subscribe(
+        this.enrichedDocumentsMetaInfosService.searchByDocumentName(param).pipe(
+            finalize(() => { this.runningFileNameSearch = false; })
+        ).subscribe(
             {
                 next: (values) => {
                     this.searchByFileNameResultsDocuments = values ? values : [];
                     this.addSourceDocuments(this.searchByFileNameResultsDocuments);
-                },
-                complete: () => {
-                    this.runningSemanticSearch = false;
                 }
             }
         );

--- a/gebo.ui/projects/gebo-ai-reusable-ui/src/styles.scss
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/src/styles.scss
@@ -132,7 +132,8 @@ label {
 .pi.pi-google-workspace,
 .pi.pi-google-drive,
 .pi.pi-confluence,
-.pi.pi-jira {
+.pi.pi-jira,
+.pi.pi-aws-s3 {
   display: inline-block;
   width: 1.5em;
   height: 1.5em;
@@ -169,6 +170,10 @@ label {
 
 .pi.pi-git {
   background-image: url("assets/3rdparty/git-svgrepo-com.svg");
+}
+
+.pi.pi-aws-s3 {
+  background-image: url("assets/oauth2/aws-svgrepo-com.svg");
 }
 
 .pi.pi-deep-search {


### PR DESCRIPTION
## Summary
- AWS S3 data-source icon reused the OAuth2-picker's larger `.pi-amazon` CSS class, rendering oversized and non-grayscale in the "Add data sources" menu; gave it its own `.pi-aws-s3` class sized like its siblings (git, jira, confluence, sharepoint).
- The "Choose files to chat with" panel's filename search reset the wrong loading flag on `complete`, and none of the panel's async calls reset their flags on `error` — a failed/interrupted request (including ones silently converted by the global auth interceptor) left the BlockUI lock permanently stuck. Switched all affected calls to rxjs `finalize()` so the mask always clears.

## Test plan
- [x] Rebuilt Angular UI + monolith, redeployed the Docker stack against existing data volumes
- [x] Verified live in browser: AWS S3 icon now renders at the same size/grayscale as sibling icons in the "Add data sources" menu
- [x] Verified live in browser: filename search in "Choose files to chat with" completes and the BlockUI lock reliably clears across repeated searches and tab switches