### PR TITLE
fix(oauth2): repair Microsoft Entra ID multitenant tenant substitution

### DIFF
--- a/gebo.architecture.parent/gebo.architecture.security/src/main/resources/oauth2-library/oauth2-library.yml
+++ b/gebo.architecture.parent/gebo.architecture.security/src/main/resources/oauth2-library/oauth2-library.yml
@@ -26,11 +26,11 @@ ai.gebo.oauth2.library:
       userNameAttribute: id
 
     - provider: microsoft_multitenant
-      authorizationUri: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
-      tokenUri: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+      authorizationUri: "https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/authorize"
+      tokenUri: "https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token"
       userInfoUri: "https://graph.microsoft.com/oidc/userinfo"
-      issuerUri: "https://login.microsoftonline.com/{tenant-id}/v2.0"
-      jwkSetUri: "https://login.microsoftonline.com/{tenant-id}/discovery/v2.0/keys"
+      issuerUri: "https://login.microsoftonline.com/{tenantId}/v2.0"
+      jwkSetUri: "https://login.microsoftonline.com/{tenantId}/discovery/v2.0/keys"
       userNameAttribute: id
 
   #- provider: facebook


### PR DESCRIPTION
## Summary
- `authorizationUri`/`tokenUri` for the `microsoft_multitenant` SSO provider were hardcoded to Microsoft's `/common/` endpoint, so registering with a specific `tenantId` never actually restricted sign-in to that organization — the feature didn't do what its "private organizations" label promised.
- `issuerUri`/`jwkSetUri` used a `{tenant-id}` (hyphenated) placeholder, but the only value ever collected from the admin form is keyed `tenantId` (camelCase). The substitution code does an exact string replace, so the placeholder was never resolved and these endpoints came out as the literal, non-working string `.../{tenant-id}/...`.
- All four endpoints now consistently use `{tenantId}`, matching the actual custom attribute key, so a multitenant registration resolves to real, tenant-scoped Microsoft endpoints.

## Test plan
- [x] Rebuilt the monolith, redeployed the local Docker stack
- [x] Verified live by extracting `oauth2-library.yml` from inside the running container's bootable jar — confirmed the fixed URLs are what's actually deployed
- [ ] Not yet smoke-tested against a real Microsoft Entra tenant (no sandbox tenant available in this environment)