### PR TITLE
fix(ui): correct mislabeled Deep search setup panel header

### DIFF
--- a/gebo.ui/projects/gebo-ai-admin-ui/src/lib/setup-wizard/deep-search-wizard.component.html
+++ b/gebo.ui/projects/gebo-ai-admin-ui/src/lib/setup-wizard/deep-search-wizard.component.html
@@ -1,7 +1,7 @@
 <p-blockUI id="BlockUILock"  [target]="instModeUI" [blocked]="loading">
     <i class="pi pi-lock" style="font-size: 3rem"></i>
 </p-blockUI>
-<p-panel id="MainPanel" gebo-ai-label #instModeUI header="Setup company Atlassian Confluence systems">
+<p-panel id="MainPanel" gebo-ai-label #instModeUI header="Setup Deep search configuration">
     <div class="grid geboLargeButtonsBar">
 
         <div class="col-6">


### PR DESCRIPTION
## Summary
- `deep-search-wizard.component.html`'s panel header was hardcoded to "Setup company Atlassian Confluence systems" — a copy-paste leftover from the Confluence wizard template it was evidently built from. The breadcrumb ("Configure Deep search") and the "+ Deep search config" button were already correct; only the panel title was wrong.
- Now reads "Setup Deep search configuration".

## Test plan
- [x] Rebuilt the monolith, redeployed the local Docker stack
- [x] Verified live in browser: heading now shows correctly