### PR TITLE
fix(chat): store LLM-generated resources with their extension so re-ingestion resolves the real file

### DIFF
--- a/gebo.architecture.parent/gebo.architecture.chat.abstraction.layer/src/main/java/ai/gebo/llms/chat/abstraction/layer/services/impl/GChatStorageAreaServiceImpl.java
+++ b/gebo.architecture.parent/gebo.architecture.chat.abstraction.layer/src/main/java/ai/gebo/llms/chat/abstraction/layer/services/impl/GChatStorageAreaServiceImpl.java
@@ -289,13 +289,20 @@ public class GChatStorageAreaServiceImpl implements IGChatStorageAreaService {
 		String extension = getExtension(media);
 		resource.setExtension(extension);
 		Path path = getSessionPath(userSessionCode);
-		Path out = Path.of(path.toString(), resource.getCode());
+		Path out = Path.of(path.toString(), getGeneratedResourceRelativeFilePath(resource));
 		try (OutputStream os = Files.newOutputStream(out)) {
 			IOUtils.write(media.getDataAsByteArray(), os);
 			os.flush();
 		}
 		resource = llmGeneratedResourceRepository.insert(resource);
 		return resource;
+	}
+
+	// LLMGeneratedResource is stored on disk with its extension so that it can
+	// later be re-read as a properly typed file (content-type probing, ingestion) -
+	// mirroring UserUploadContentServerSide.getRelativeFilePath().
+	private String getGeneratedResourceRelativeFilePath(LLMGeneratedResource resource) {
+		return resource.getCode() + (resource.getExtension() != null ? resource.getExtension() : "");
 	}
 
 	private String getExtension(Media media) {
@@ -324,22 +331,33 @@ public class GChatStorageAreaServiceImpl implements IGChatStorageAreaService {
 	@Override
 	public InputStream streamContent(LLMGeneratedResource generated) throws IOException {
 		this.checkBeingOwnerAndExists(generated.getUserContextCode());
-		Path path = getSessionPath(generated.getUserContextCode());
-		Path outPath = Path.of(path.toString(), generated.getCode());
+		Path outPath = getGeneratedResourceFilePath(generated);
 		return Files.newInputStream(outPath);
+	}
+
+	private Path getGeneratedResourceFilePath(LLMGeneratedResource generated) throws IOException {
+		Path path = getSessionPath(generated.getUserContextCode());
+		return Path.of(path.toString(), getGeneratedResourceRelativeFilePath(generated));
 	}
 
 	@Override
 	public List<Document> getIngestedContentsOf(LLMGeneratedResource generated)
 			throws IOException, GeboContentHandlerSystemException, GeboIngestionException {
-		InputStream is = streamContent(generated);
-		if (is == null)
+		Path filePath = getGeneratedResourceFilePath(generated);
+		if (!Files.exists(filePath))
 			return List.of();
-		GDocumentReference doc = documentReferenceFactory.createReference(Path.of(generated.getFileName()));
-		IngestionHandlerData ingested = ingestionHandler.handleContent(doc, is);
-		if (ingested.isUnmanagedContent())
-			return List.of();
-		return ingested.getStream().toList();
+		// The reference must be built from the real on-disk path (with its
+		// extension) so createReference() can stat the file and probe its
+		// content type - generated.getFileName() is only a display label, not
+		// a resolvable path, and was previously (wrongly) passed here directly,
+		// which is what threw NoSuchFileException for generated images.
+		GDocumentReference doc = documentReferenceFactory.createReference(filePath);
+		try (InputStream is = Files.newInputStream(filePath)) {
+			IngestionHandlerData ingested = ingestionHandler.handleContent(doc, is);
+			if (ingested.isUnmanagedContent())
+				return List.of();
+			return ingested.getStream().toList();
+		}
 	}
 
 }


### PR DESCRIPTION
## Summary
- Every "Image generation" chat request threw `GeboChatSessionLifecycleException: Exception ingesting a generated resource` (caused by `NoSuchFileException`) inside `GChatSessionLifeCycleService.endRequest()`, silently swallowed from the UI — the image still displayed, but the exception fired on the backend every single time.
- Root cause: `GChatStorageAreaServiceImpl.addMedia()` writes generated images to disk under a bare UUID with **no extension**, but `getIngestedContentsOf(LLMGeneratedResource)` built the `GDocumentReference` from `generated.getFileName()` — just a display label copied from `Media.getName()` (e.g. `"generated-image-<uuid>.png"`), never a resolvable filesystem path. `createReference()` needs a real, existing file to `stat()`/probe content-type on, so this always threw.
- Fix: store and resolve the generated resource's file consistently by `code + extension` across `addMedia()` / `streamContent()` / `getIngestedContentsOf()`, mirroring the pattern already used for user-uploaded content (`UserUploadContentServerSide.getRelativeFilePath()`).

## Test plan
- [x] Rebuilt the local Docker image and reproduced the exception live via the "Image generation" chat menu; confirmed it fires on every request before the fix.
- [x] Applied the fix, rebuilt, and regenerated two test images (apple, bicycle) — no exceptions in the backend logs, images display correctly.
- [ ] CI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxB8hNQiHRaqiKeYVVFj7H