### PR TITLE
fix(ui): repair the knowledge base wizard's "choose data source type" step

### DIFF
--- a/gebo.ui/projects/gebo-ai-admin-ui/src/lib/admin-ui/gebo-ai-admin.module.ts
+++ b/gebo.ui/projects/gebo-ai-admin-ui/src/lib/admin-ui/gebo-ai-admin.module.ts
@@ -25,7 +25,7 @@
  * The module imports numerous Angular and PrimeNG modules for UI components and
  * declares all the admin components needed for the Gebo.ai administrative interface.
  */
-import { BrowseContentModule, EditableListboxModule, GeboAIContentReindexModule, GeboAIFileTypesModule, GeboAiRelationListModule, GeboAIReusableChatModule, GeboOauth2SecretModule, GeboUIArchitectureModule, ProjectAddContextMenuModule, GeboAIContentSelectionFilterModule, GeboAIFieldTranslationContainerModule, GEBO_AI_MODULE, GeboAINotificationsModule, GeboAIChatModelUseModule, GEBO_UI_ENTITY_FORM_TOKEN, GeboUIEntityFormConfig, GeboAILLMSUsageDashboardModule, GeboAIWorkflowStatsDashboardModule, GeboBlockableContainerDirective } from "@Gebo.ai/reusable-ui";
+import { BrowseContentModule, EditableListboxModule, GeboAIContentReindexModule, GeboAIFileTypesModule, GeboAiRelationListModule, GeboAIReusableChatModule, GeboOauth2SecretModule, GeboUIArchitectureModule, ProjectAddContextMenuModule, GeboAIContentSelectionFilterModule, GeboAIFieldTranslationContainerModule, GEBO_AI_MODULE, GeboAINotificationsModule, GeboAIChatModelUseModule, GEBO_UI_ENTITY_FORM_TOKEN, GeboUIEntityFormConfig, GeboAILLMSUsageDashboardModule, GeboAIWorkflowStatsDashboardModule, GeboBlockableContainerDirective, GeboAIChooseDataSourceTypeComponent } from "@Gebo.ai/reusable-ui";
 import { CommonModule } from "@angular/common";
 import { NgModule, ModuleWithProviders } from "@angular/core";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
@@ -262,6 +262,8 @@ export class GeboAiAdminModule {
           { provide: GEBO_UI_ENTITY_FORM_TOKEN, useValue: { entityName: 'GOllamaEmbeddingModelConfig', entityAliases: ['ai.gebo.llms.ollama.model.GOllamaEmbeddingModelConfig'], entityUI: GeboAIOllamaEmbedModelAdminComponent } as GeboUIEntityFormConfig, multi: true },
 
           { provide: GEBO_UI_ENTITY_FORM_TOKEN, useValue: { entityName: 'GProject', entityAliases: ['ai.gebo.knlowledgebase.model.projects.GProject'], entityUI: GeboAiProjectAdminComponent } as GeboUIEntityFormConfig, multi: true },
+
+          { provide: GEBO_UI_ENTITY_FORM_TOKEN, useValue: { entityName: 'ChooseDataSourceType', entityUI: GeboAIChooseDataSourceTypeComponent } as GeboUIEntityFormConfig, multi: true },
 
           { provide: GEBO_UI_ENTITY_FORM_TOKEN, useValue: { entityName: 'GOpenAIChatModelConfig', entityAliases: ['ai.gebo.llms.openai.model.GOpenAIChatModelConfig'], entityUI: GeboAIOpenAIChatModelAdminComponent } as GeboUIEntityFormConfig, multi: true },
 

--- a/gebo.ui/projects/gebo-ai-reusable-ui/src/lib/controls/add-project-endpoint-component/choose-data-source-type.component.ts
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/src/lib/controls/add-project-endpoint-component/choose-data-source-type.component.ts
@@ -118,8 +118,8 @@ export class GeboAIChooseDataSourceTypeComponent extends BaseEntityEditingCompon
                         this.subscription.unsubscribe();
                         this.subscription=undefined;
                     }
-                    this.items = this.kbTreeSearchService.generateAddToProjectMenuEnglish(false, this.project, actionConsumer, actionsCallback);
-                    this.subscription=this.kbTreeSearchService.generateAddToProjectMenu(false, this.project, actionConsumer, actionsCallback).subscribe({
+                    this.items = this.kbTreeSearchService.generateAddToProjectMenuEnglish(false, this.project, actionConsumer, actionsCallback, this.wizardStepsConfigurations, this.actualWizardStepConfigrationId);
+                    this.subscription=this.kbTreeSearchService.generateAddToProjectMenu(false, this.project, actionConsumer, actionsCallback, this.wizardStepsConfigurations, this.actualWizardStepConfigrationId).subscribe({
                         next:(menuItems)=>{
                             if (menuItems) {
                                 this.items=menuItems;

--- a/gebo.ui/projects/gebo-ai-reusable-ui/src/lib/services/pluggable-knowledge-base-admin-tree-search.service.ts
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/src/lib/services/pluggable-knowledge-base-admin-tree-search.service.ts
@@ -245,7 +245,7 @@ export class GeboAIPluggableKnowledgeAdminBaseTreeSearchService {
         if (options) {
             options.forEach(option => {
                 items.push({
-                    id: option.projecteEndpointClassName.replaceAll(".", "_"),
+                    id: option.projecteEndpointClassName,
                     icon: option.addProjectEndpointicon,
                     label: option.addProjectEndpointLabel,
                     title: option.addProjectEndpointTitle,


### PR DESCRIPTION
## Summary
Step 3 of the 5-step knowledge base creation wizard ("+ Data source" in the summary list, and the inline step-2→3 transition) was a complete dead end — clicking did nothing: no dialog, no navigation, no network request, no console error. Three compounding bugs, found and fixed while investigating live with the repo owner:

1. `GeboAIChooseDataSourceTypeComponent` was never registered via `GEBO_UI_ENTITY_FORM_TOKEN` in `gebo-ai-admin.module.ts`, so the central action-routing service had no listener for `targetType: "ChooseDataSourceType"` and `routeEvent()` silently no-opped.
2. Once registered, the dialog opened but rendered an **empty** data source type list: `refreshUI()` never forwarded the inherited `wizardStepsConfigurations`/`actualWizardStepConfigrationId` inputs into `generateAddToProjectMenuEnglish`/`generateAddToProjectMenu`, unlike the working sibling `ProjectAddContextMenuComponent`.
3. Selecting a data source type and clicking Forward also did nothing: each menu item's `id` was built from `projecteEndpointClassName.replaceAll(".", "_")` (e.g. `ai_gebo_uploads_content_handler_GUploadsProjectEndpoint`), which never matches the dotted `entityAliases` registered for that endpoint type (e.g. `ai.gebo.uploads.content.handler.GUploadsProjectEndpoint`), since routing does exact string matching with no normalization. The `id` is only ever used for JS equality/routing, never as an HTML id or CSS selector, so the underscore-escaping served no purpose.

## Test plan
- [x] Rebuilt the local Docker image after each fix and verified live, end to end: all 9 data source types now list correctly in step 3, selecting one (tested "uploaded files") opens its create form in step 4, and publishing in step 5 runs the full ingestion pipeline (analyzing → tokenization → embedding → full-text indexing) to completion ("Processed completely").
- [ ] CI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxB8hNQiHRaqiKeYVVFj7H