### PR TITLE
fix(tests): route job-summary polling through JobStatusControllerApi after monolithic stub split

### DIFF
--- a/compile-prod.sh
+++ b/compile-prod.sh
@@ -1,0 +1,1 @@
+mvn clean package -P bootables,angular-ui  -DskipTests

--- a/integration-tests/full-setup-and-use-integration-tests/src/test/java/ai/gebo/full_setup_use/tests/AbstractFullSetupUseChatTest.java
+++ b/integration-tests/full-setup-and-use-integration-tests/src/test/java/ai/gebo/full_setup_use/tests/AbstractFullSetupUseChatTest.java
@@ -27,6 +27,7 @@ import ai.gebo.monolithic.api.client.api.FileSystemSharesSettingControllerApi;
 import ai.gebo.monolithic.api.client.api.GeboChatPipelinesControllerApi;
 import ai.gebo.monolithic.api.client.api.GeboRagChatControllerApi;
 import ai.gebo.monolithic.api.client.api.JobLauncherControllerApi;
+import ai.gebo.monolithic.api.client.api.JobStatusControllerApi;
 import ai.gebo.monolithic.api.client.invoker.ApiClient;
 import ai.gebo.monolithic.api.client.model.GFileSystemShareReference;
 import ai.gebo.monolithic.api.client.model.GObjectRefGProjectEndpoint;
@@ -137,6 +138,7 @@ public abstract class AbstractFullSetupUseChatTest extends AbstractVendorSetupAn
 			endpoint = persistentObjectManager.update(endpoint);
 			renew(apiClient);
 			JobLauncherControllerApi jobLauncherApi = new JobLauncherControllerApi(apiClient);
+			JobStatusControllerApi jobStatusApi = new JobStatusControllerApi(apiClient);
 			GObjectRefGProjectEndpoint ref = new GObjectRefGProjectEndpoint();
 			ref.setCode(endpoint.getCode());
 			ref.setClassName(endpoint.getClass().getName());
@@ -151,12 +153,12 @@ public abstract class AbstractFullSetupUseChatTest extends AbstractVendorSetupAn
 			long currentTime = System.currentTimeMillis();
 			do {
 				Thread.currentThread().sleep(sleepTime);
-				summary = jobLauncherApi.getJobSummary(launchedJob.getResult().getCode());
+				summary = jobStatusApi.getJobSummary(launchedJob.getResult().getCode());
 				printSummary(summary);
 				renew(apiClient);
 				currentTime = System.currentTimeMillis();
 			} while (!summary.getWorkflowStatus().isFinished() && ((currentTime - initialTime) <= maxIterationTime));
-			summary = jobLauncherApi.getJobSummary(launchedJob.getResult().getCode());
+			summary = jobStatusApi.getJobSummary(launchedJob.getResult().getCode());
 			assertTrue(summary.getWorkflowStatus().isFinished(), "The pubblication job has to be finished");
 			ThreasholdAutotuneProcessResultRepository autotuneRepository = runtimeBinder
 					.getImplementationOf(ThreasholdAutotuneProcessResultRepository.class);


### PR DESCRIPTION
## Problem

The `full-setup-and-use-integration-tests` module no longer compiles after the monolithic REST template client (`gebo.monolithic.api.resttemplate.client`) was regenerated from the live OpenAPI spec. The server split the job-status endpoint out of `JobLauncherController` into its own `JobStatusController`, so the regenerated stub dropped `getJobSummary(String)` from `JobLauncherControllerApi` (it now exposes only `createJob`, `abortJob`, `getHasRunningJobs`).

As a result `AbstractFullSetupUseChatTest` — and its subclasses `FullSetupUseAndPipelineTest` / `FullSetupUseAndAgenticChatTest` — fail to compile:

```
AbstractFullSetupUseChatTest.java:[154,57] cannot find symbol
  symbol:   method getJobSummary(java.lang.String)
  location: variable jobLauncherApi of type JobLauncherControllerApi
```

## Fix

`getJobSummary(String)` now lives on `JobStatusControllerApi` (`/api/admin/JobStatusController/getJobSummary`). Updated `AbstractFullSetupUseChatTest` to:

- import `ai.gebo.monolithic.api.client.api.JobStatusControllerApi`
- instantiate a `JobStatusControllerApi` alongside the existing `jobLauncherApi`
- route both job-summary polling calls (the loop poll and the final post-loop check) through `jobStatusApi.getJobSummary(...)`

`createJob` still comes from `JobLauncherControllerApi`, so launching is unchanged. The two subclasses only call `runFullSetupAndChatSession`, so they needed no changes. Sibling tests `ChatPipelineTests` and `HistoryCoerencyTest` (which extend `AbstractVendorSetupAndUseTest` directly) were unaffected, and no other integration-test module references `getJobSummary` / `JobLauncherControllerApi`.

## Verification

```
mvn test-compile -DskipTests -pl full-setup-and-use-integration-tests
# BUILD SUCCESS
```

These are heavy integration tests (require a live `FullSetupSecret` env config, Qdrant testcontainer, vendor LLM keys), so they are not executed in CI here — only compilation is restored.