### PR TITLE
test(integration): use random port for in-process gebo.ai to avoid collisions on 12999

### DIFF
--- a/gebo.architecture.parent/gebo.architecture.integration.tests/src/main/java/ai/gebo/architecture/integration/tests/AbstractVendorSetupAndUseTest.java
+++ b/gebo.architecture.parent/gebo.architecture.integration.tests/src/main/java/ai/gebo/architecture/integration/tests/AbstractVendorSetupAndUseTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -117,6 +118,18 @@ public class AbstractVendorSetupAndUseTest extends AbstractGeboMonolithicIntegra
 	protected GeboVectorStoreConfigurationService vectorStoreConfigurationService;
 	@Autowired
 	protected Environment environment;
+	/**
+	 * Port the in-process Gebo.ai web server actually bound to. Populated by
+	 * Spring Boot when the test context boots with {@code WebEnvironment.RANDOM_PORT}
+	 * (or {@code DEFINED_PORT}); remains {@code 0} for non-web contexts. When set,
+	 * it overrides the {@code host}/{@code port} declared in the
+	 * {@code FullSetupSecret} setup so that every API client built from
+	 * {@link #executeSystemSetupBySecret()} points at the in-process server instead
+	 * of a fixed port (e.g. 12999), preventing collisions with any other Gebo.ai
+	 * instance already running on that fixed port.
+	 */
+	@Value("${local.server.port:0}")
+	protected int localServerPort = 0;
 
 	protected ApiClient createApiClient(String host, int port, SecurityHeaderData header) {
 		RestTemplate restTemplate = createRestTemplate();
@@ -436,6 +449,12 @@ public class AbstractVendorSetupAndUseTest extends AbstractGeboMonolithicIntegra
 				+ FULL_SETUP_ENVIRONMENT_JSON_STRING + " must contain a valid json setup configuration");
 		ObjectMapper objectMapper = new ObjectMapper();
 		IntegrationTestSetup setup = objectMapper.readValue(jsonSetup, IntegrationTestSetup.class);
+		// Redirect every client at the in-process server's actual port so the suite
+		// never competes with another Gebo.ai instance bound to the fixed 12999 port.
+		if (localServerPort > 0 && setup.getSystemSetup() != null) {
+			setup.getSystemSetup().setHost("localhost");
+			setup.getSystemSetup().setPort(localServerPort);
+		}
 		return executingSystemSetup(setup);
 	}
 

--- a/integration-tests/full-setup-and-use-integration-tests/src/test/java/ai/gebo/full_setup_use/tests/ChatPipelineTests.java
+++ b/integration-tests/full-setup-and-use-integration-tests/src/test/java/ai/gebo/full_setup_use/tests/ChatPipelineTests.java
@@ -28,7 +28,7 @@ import ai.gebo.monolithic.api.client.model.PageGLookupEntry;
 import ai.gebo.monolithic.api.client.model.PipelineRequestBody;
 import ai.gebo.monolithic.app.Main;
 
-@SpringBootTest(classes = Main.class, webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = Main.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 public class ChatPipelineTests extends AbstractVendorSetupAndUseTest {
 	@Autowired
 	IGRuntimeBinder runtimeBinder;

--- a/integration-tests/full-setup-and-use-integration-tests/src/test/java/ai/gebo/full_setup_use/tests/FullSetupUseAndAgenticChatTest.java
+++ b/integration-tests/full-setup-and-use-integration-tests/src/test/java/ai/gebo/full_setup_use/tests/FullSetupUseAndAgenticChatTest.java
@@ -29,7 +29,7 @@ import ai.gebo.monolithic.app.Main;
  *
  * @see FullSetupUseAndPipelineTest for the pipeline-router counterpart
  */
-@SpringBootTest(classes = Main.class, webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = Main.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = "ai.gebo.agents.standard.enabled=true")
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class FullSetupUseAndAgenticChatTest extends AbstractFullSetupUseChatTest {

--- a/integration-tests/full-setup-and-use-integration-tests/src/test/java/ai/gebo/full_setup_use/tests/FullSetupUseAndPipelineTest.java
+++ b/integration-tests/full-setup-and-use-integration-tests/src/test/java/ai/gebo/full_setup_use/tests/FullSetupUseAndPipelineTest.java
@@ -23,7 +23,7 @@ import ai.gebo.monolithic.app.Main;
  *
  * @see FullSetupUseAndAgenticChatTest for the network-of-agents counterpart
  */
-@SpringBootTest(classes = Main.class, webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = Main.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = "ai.gebo.agents.standard.enabled=false")
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class FullSetupUseAndPipelineTest extends AbstractFullSetupUseChatTest {

--- a/integration-tests/full-setup-and-use-integration-tests/src/test/java/ai/gebo/full_setup_use/tests/HistoryCoerencyTest.java
+++ b/integration-tests/full-setup-and-use-integration-tests/src/test/java/ai/gebo/full_setup_use/tests/HistoryCoerencyTest.java
@@ -11,7 +11,7 @@ import ai.gebo.architecture.integration.tests.model.TestGeboSystemInfo;
 import ai.gebo.monolithic.api.client.invoker.ApiClient;
 import ai.gebo.monolithic.app.Main;
 
-@SpringBootTest(classes = Main.class, webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = Main.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 public class HistoryCoerencyTest extends AbstractVendorSetupAndUseTest {
 
 	public void historyCoerencyTest() throws DatabindException, JacksonException, InterruptedException {

--- a/integration-tests/full-setup-and-use-integration-tests/src/test/resources/application.yml
+++ b/integration-tests/full-setup-and-use-integration-tests/src/test/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 12999
+  port: 0
   compression:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json


### PR DESCRIPTION
## Problem

The `full-setup-and-use-integration-tests` module boots the Gebo.ai web app in-process on a fixed port (`server.port: 12999`, `WebEnvironment.DEFINED_PORT`). If another Gebo.ai instance is already running on 12999 (locally, in CI, etc.), the test context fails to bind, and the API clients (configured from the `FullSetupSecret` JSON, which also carries 12999) would point at the wrong server.

## Fix

Make the in-process web server bind a random free port and have every client follow it:

- `src/test/resources/application.yml`: `server.port: 12999` → `0` (Spring picks an ephemeral port).
- The 4 test classes (`FullSetupUseAndPipelineTest`, `FullSetupUseAndAgenticChatTest`, `HistoryCoerencyTest`, `ChatPipelineTests`): `WebEnvironment.DEFINED_PORT` → `RANDOM_PORT`.
- Shared base `AbstractVendorSetupAndUseTest` (in `gebo.architecture.integration.tests`): added `@Value("${local.server.port:0}") int localServerPort` and, in `executeSystemSetupBySecret()`, override the parsed `TestSystemSetup` host/port with `localhost`/`localServerPort` when it is set. This propagates through `executingSystemSetup` → `createApiClient`, `renew`, and the returned `TestGeboSystemInfo`, so all generated API clients target the in-process random port rather than the hardcoded 12999 from the secret.

`@Value(...)` with a default of `0` keeps the base class usable from non-web contexts (the value simply stays 0 and the override is skipped).

## Verification

```
mvn test-compile -DskipTests -pl full-setup-and-use-integration-tests
# BUILD SUCCESS
```

Heavy integration tests (live `FullSetupSecret`, testcontainers, vendor LLM keys) are not executed in CI — only compilation is restored.