### PR TITLE
fix(tests): use spring.mongodb.* instead of deprecated spring.data.mongodb.host/port

### DIFF
--- a/gebo.architecture.parent/gebo.architecture.integration.tests/src/main/java/ai/gebo/architecture/integration/tests/AbstractGeboMonolithicIntegrationTests.java
+++ b/gebo.architecture.parent/gebo.architecture.integration.tests/src/main/java/ai/gebo/architecture/integration/tests/AbstractGeboMonolithicIntegrationTests.java
@@ -214,8 +214,14 @@ public abstract class AbstractGeboMonolithicIntegrationTests {
 		mongoDBContainer.start();
 		neo4jContainer.start();
 		opensearch.start();
-		registry.add("spring.data.mongodb.host", mongoDBContainer::getHost);
-		registry.add("spring.data.mongodb.port", mongoDBContainer::getFirstMappedPort);
+		// Spring Boot 4.x moved the MongoDB connection properties from spring.data.mongodb.*
+		// to spring.mongodb.* (DataMongoProperties no longer carries host/port/uri; they
+		// now live on MongoProperties bound to "spring.mongodb"). The app's real Mongo
+		// client is built by MongoConfig from ai.gebo.mongodb.connectionString below, but
+		// we keep the Spring Boot keys on the new prefix so any auto-configured Mongo
+		// points at the testcontainer and PropertiesMigrationListener stays quiet.
+		registry.add("spring.mongodb.host", mongoDBContainer::getHost);
+		registry.add("spring.mongodb.port", mongoDBContainer::getFirstMappedPort);
 		// ai.gebo.mongodb.enabled: true
 		// databaseName: gebo-ai-tests
 		// connectionString: mongodb://localhost:27027/gebo-ai-tests?authSource=admin


### PR DESCRIPTION
## Problem

Spring Boot 4.x moved the MongoDB connection properties from `spring.data.mongodb.*` to `spring.mongodb.*` (`DataMongoProperties` no longer carries `host`/`port`/`uri`; they now live on `MongoProperties` bound to `spring.mongodb`). The shared `AbstractGeboMonolithicIntegrationTests` base registered the testcontainer host/port under the old keys:

```java
registry.add("spring.data.mongodb.host", mongoDBContainer::getHost);
registry.add("spring.data.mongodb.port", mongoDBContainer::getFirstMappedPort);
```

Spring's `PropertiesMigrationListener` flagged them at ERROR level:

```
Property source 'Dynamic Test Properties':
    Key: spring.data.mongodb.host
        Reason: Replacement key 'spring.mongodb.host' uses an incompatible target type
    Key: spring.data.mongodb.port
        Reason: Replacement key 'spring.mongodb.port' uses an incompatible target type
```

This affected the full-setup integration tests under Jenkins and every `gebo.ai.app` test (they extend `AbstractBaseIntegrationTest` → `AbstractGeboMonolithicIntegrationTestsWithFakeLLMS` → `AbstractGeboMonolithicIntegrationTests`).

## Fix

Repoint the two `@DynamicPropertySource` registrations to the new prefix in `AbstractGeboMonolithicIntegrationTests`:

```java
registry.add("spring.mongodb.host", mongoDBContainer::getHost);
registry.add("spring.mongodb.port", mongoDBContainer::getFirstMappedPort);
```

The app's real Mongo client is still built by `MongoConfig` from `ai.gebo.mongodb.connectionString` (unchanged); the Spring Boot keys are kept on the new prefix only so any auto-configured Mongo points at the testcontainer and the properties-migrator stays quiet.

Scope is limited to the shared monolithic base as discussed; the same deprecated pattern exists in 19 microservice `*ContextTest.java` files but is out of scope here.

## Verification

`mvn clean -pl :gebo.ai.app -am test` → `BUILD SUCCESS` (full rebuild + `gebo.ai.app` tests, ~16 min). The deprecated-key ERROR no longer appears in the logs.