### PR TITLE
fix(audio-control): mobile/cross-browser recording and playback bugs

### DIFF
--- a/gebo.ui/projects/gebo-ai-reusable-ui/src/lib/controls/audio-control/audio-control.component.html
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/src/lib/controls/audio-control/audio-control.component.html
@@ -19,7 +19,7 @@
     [disabled]="disabled || playMode"
     (onClick)="startRecording()"
     icon="pi pi-microphone"
-    title="Start recording an audio track and send it"
+    [title]="errorMessage || 'Start recording an audio track and send it'"
     [text]="viewLabels"
     rounded="true"
     class="custom-blue-btn"

--- a/gebo.ui/projects/gebo-ai-reusable-ui/src/lib/controls/audio-control/audio-control.component.ts
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/src/lib/controls/audio-control/audio-control.component.ts
@@ -21,6 +21,9 @@
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from "@angular/core";
 import { fieldHostComponentName, GEBO_AI_FIELD_HOST, GEBO_AI_MODULE } from "../field-host-component-iface/field-host-component-iface";
 
+/** Why recording is currently unavailable, so callers can show a specific message instead of a generic error. */
+export type GeboAudioErrorReason = 'permission-denied' | 'no-device' | 'device-busy' | 'insecure-context' | 'unsupported' | 'unknown';
+
 @Component({
     selector: "gebo-ai-audio-component",
     templateUrl: "audio-control.component.html",
@@ -36,8 +39,12 @@ export class GeboAIAudioControlComponent implements OnInit, OnChanges, OnDestroy
     public recording: boolean = false;
     /** Indicates if there was an error during recording */
     public errorState: boolean = false;
+    /** Why errorState is set - lets callers show a specific message instead of a generic one */
+    public errorReason?: GeboAudioErrorReason;
     /** MediaRecorder instance used to capture audio */
     private mediaRecorder?: MediaRecorder;
+    /** Microphone stream backing mediaRecorder - kept so its tracks can be stopped explicitly, otherwise the mic stays active (OS/browser indicator stays lit) after recording ends */
+    private mediaStream?: MediaStream;
     /** Array to store audio data chunks during recording */
     private audioChunks: BlobPart[] = [];
     /** Indicates if audio is currently playing */
@@ -51,7 +58,25 @@ export class GeboAIAudioControlComponent implements OnInit, OnChanges, OnDestroy
     @Input() public playAudioTrack?: Blob;
     /** Event emitter that fires when audio recording is completed */
     @Output() public onAudioTrack: EventEmitter<Blob> = new EventEmitter();
-    
+
+    /** Ordered by preference - webm/opus (Chrome/Firefox/desktop) then the mp4/aac variants Safari/iOS actually supports */
+    private static readonly MIME_CANDIDATES = ['audio/webm;codecs=opus', 'audio/mp4', 'audio/aac', 'audio/mpeg'];
+
+    /** Human-readable message matching errorReason, or undefined when there is no error */
+    public get errorMessage(): string | undefined {
+        if (!this.errorState || !this.errorReason) {
+            return undefined;
+        }
+        switch (this.errorReason) {
+            case 'permission-denied': return 'Microphone access was denied. Check your browser/site permissions and try again.';
+            case 'no-device': return 'No microphone was found on this device.';
+            case 'device-busy': return 'The microphone is already in use by another application.';
+            case 'insecure-context': return 'Audio recording requires a secure (HTTPS) connection.';
+            case 'unsupported': return 'Audio recording is not supported on this browser.';
+            default: return 'Unable to access the microphone.';
+        }
+    }
+
     /**
      * Lifecycle hook that is called after data-bound properties are initialized
      */
@@ -70,10 +95,15 @@ export class GeboAIAudioControlComponent implements OnInit, OnChanges, OnDestroy
     }
 
     /**
-     * Lifecycle hook that is called when the component is destroyed
+     * Lifecycle hook that is called when the component is destroyed.
+     * Releases the MediaRecorder and microphone stream if a recording was left in progress.
      */
     ngOnDestroy(): void {
-
+        if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') {
+            try { this.mediaRecorder.stop(); } catch (e) { }
+        }
+        this.mediaRecorder = undefined;
+        this.releaseMediaStream();
     }
 
     /** HTML Audio element for playback control */
@@ -89,10 +119,19 @@ export class GeboAIAudioControlComponent implements OnInit, OnChanges, OnDestroy
             const audioUrl = URL.createObjectURL(this.playAudioTrack);
             const audio = new Audio(audioUrl);
             audio.play().then(()=>{
-                
-            },()=>{});
+
+            },()=>{
+                // Blocked by the browser's autoplay policy - common on mobile Safari/Chrome
+                // since this play() runs from a change-detection callback, not directly
+                // inside a user gesture. Fall back to the "paused" state so the existing
+                // continuePlay() button (invoked from a real click handler, which autoplay
+                // policies allow) can start it instead of leaving a stuck fake-playing UI.
+                this.playMode = false;
+                this.playPaused = true;
+            });
             audio.onended=(ev)=>{
                 this.playMode=false;
+                this.playPaused=false;
             }
 
             this.audio = audio;
@@ -134,6 +173,8 @@ export class GeboAIAudioControlComponent implements OnInit, OnChanges, OnDestroy
                     this.audioChunks = [];
                     this.recording = false;
                     this.errorState = false;
+                    this.errorReason = undefined;
+                    this.releaseMediaStream();
                 }
             } catch (e) { }
         }
@@ -146,20 +187,41 @@ export class GeboAIAudioControlComponent implements OnInit, OnChanges, OnDestroy
     startRecording() {
         this.recording = true;
         this.errorState = false;
+        this.errorReason = undefined;
+
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+            // navigator.mediaDevices is undefined on insecure contexts (getUserMedia is only
+            // exposed over HTTPS/localhost) as well as on browsers too old to implement it -
+            // calling .getUserMedia straight on undefined would throw synchronously, before
+            // any promise/catch exists to route it into errorState.
+            this.setError(typeof window !== 'undefined' && window.isSecureContext === false ? 'insecure-context' : 'unsupported');
+            return;
+        }
+        if (typeof MediaRecorder === 'undefined') {
+            this.setError('unsupported');
+            return;
+        }
+
         navigator.mediaDevices.getUserMedia({ audio: true })
             .then(stream => {
-                // Try a MIME type that's commonly supported on mobile
-                const options = {
-                    mimeType: 'audio/webm; codecs=opus'
-                };
+                this.mediaStream = stream;
 
-                // Check if this MIME type is supported
-                if (!MediaRecorder.isTypeSupported(options.mimeType)) {
-                    console.warn(`${options.mimeType} is not supported on this browser. Using default settings.`);
-                    // Use the default
-                    this.mediaRecorder = new MediaRecorder(stream);
-                } else {
-                    this.mediaRecorder = new MediaRecorder(stream, options);
+                // Try MIME types in order of preference - webm/opus works on Chrome/Firefox/desktop
+                // but Safari/iOS never support it, so an explicit fallback chain is needed rather
+                // than relying on whatever MediaRecorder's undocumented per-version default produces.
+                const mimeType = GeboAIAudioControlComponent.MIME_CANDIDATES
+                    .find(candidate => MediaRecorder.isTypeSupported(candidate));
+                if (!mimeType) {
+                    console.warn('No preferred audio MIME type is supported on this browser. Using default settings.');
+                }
+
+                try {
+                    this.mediaRecorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+                } catch (e) {
+                    console.error('Unable to create a MediaRecorder on this browser', e);
+                    this.setError('unsupported');
+                    this.releaseMediaStream();
+                    return;
                 }
 
                 this.mediaRecorder.ondataavailable = event => {
@@ -172,8 +234,7 @@ export class GeboAIAudioControlComponent implements OnInit, OnChanges, OnDestroy
             })
             .catch(error => {
                 console.error('Error accessing microphone', error);
-                this.errorState = true;
-                this.recording = false;
+                this.setError(GeboAIAudioControlComponent.reasonFromError(error));
             });
     }
 
@@ -191,10 +252,40 @@ export class GeboAIAudioControlComponent implements OnInit, OnChanges, OnDestroy
                 this.audioChunks = [];
                 this.onAudioTrack.emit(audioBlob);
                 this.errorState = false;
+                this.errorReason = undefined;
                 this.mediaRecorder = undefined;
+                this.releaseMediaStream();
                 // Do something with 'audioBlob', e.g. upload or play.
 
             };
+        }
+    }
+
+    private setError(reason: GeboAudioErrorReason): void {
+        this.errorState = true;
+        this.errorReason = reason;
+        this.recording = false;
+    }
+
+    private releaseMediaStream(): void {
+        this.mediaStream?.getTracks().forEach(track => track.stop());
+        this.mediaStream = undefined;
+    }
+
+    private static reasonFromError(error: any): GeboAudioErrorReason {
+        switch (error?.name) {
+            case 'NotAllowedError':
+            case 'PermissionDeniedError':
+            case 'SecurityError':
+                return 'permission-denied';
+            case 'NotFoundError':
+            case 'DevicesNotFoundError':
+                return 'no-device';
+            case 'NotReadableError':
+            case 'TrackStartError':
+                return 'device-busy';
+            default:
+                return 'unknown';
         }
     }
 }


### PR DESCRIPTION
## Summary
Analyzed `gebo-ai-reusable-ui`'s `audio-control` component for desktop/mobile cross-client compatibility and fixed 5 issues found:

- **Mic stream leak**: `stream.getTracks()` was never stopped on stop/abort/destroy, leaving the microphone active (OS/browser indicator stays lit) after recording ends.
- **Insecure-context/unsupported-browser crash**: `navigator.mediaDevices` can be `undefined` (non-HTTPS origins, old browsers); calling `.getUserMedia` on it threw synchronously, bypassing the existing `.catch()` entirely. Now guarded up front and routed into `errorState`.
- **iOS Safari MIME gap**: only `audio/webm;codecs=opus` was tried, with an untested browser-default fallback. Added an explicit ordered MIME fallback chain (webm/opus → mp4 → aac → mpeg).
- **Mobile autoplay policy**: programmatic `play()` from `ngOnChanges` isn't inside a user gesture, so mobile Safari/Chrome can reject it; a rejection now falls back to the existing "paused" state so `continuePlay()` (a real click handler, which autoplay policies allow) can start it instead of leaving a stuck fake-playing UI.
- **Generic error state**: `errorState` was a single boolean; added a typed `errorReason` (`permission-denied`/`no-device`/`device-busy`/`insecure-context`/`unsupported`) and an `errorMessage` getter, surfaced via the record button's title.

## Test plan
- [x] `npx ng build gebo-ai-reusable-ui` - builds clean, no type errors
- [ ] Manual smoke test in a consuming app (desktop Chrome + mobile Safari) recommended before merge, since this touches MediaRecorder/getUserMedia behavior that differs materially across browsers