### PR TITLE
docs(reusable-ui): coding-assistant-facing documentation shipped in npm artifact

### DIFF
--- a/gebo.ui/projects/gebo-ai-reusable-ui/docs/00-overview.md
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/docs/00-overview.md
@@ -1,0 +1,105 @@
+# @Gebo.ai/reusable-ui — Overview
+
+Angular 21 library of components/services powering the Gebo.ai web app (chat, knowledge-base
+browsing/ingestion, admin entity forms, login/setup, usage dashboards). It is consumed by three
+sibling libraries in the same monorepo (`gebo-ai-chat-ui`, `gebo-ai-admin-ui`) and by the shell
+app (`gebo.ui/src/app`), and is also published as an installable npm package for third-party apps
+that embed Gebo.ai UI.
+
+This `docs/` folder is written for a coding assistant/agent that needs to wire up or extend
+components from this library without reading every source file first. Each doc gives real
+selectors, `@Input()`/`@Output()` names, and copy-pasteable wiring taken from this repo's own
+usage of the library — not idealized examples.
+
+## Doc map
+
+| File | Covers |
+|---|---|
+| [01-architecture.md](./01-architecture.md) | The action-routing → modal → entity-form pipeline, dynamic form groups, the setup wizard framework, notifications. Read this first — almost everything else depends on it. |
+| [02-chat-and-knowledge-base.md](./02-chat-and-knowledge-base.md) | The chat widget, deep search, document viewer/picker, virtual-filesystem browser, userspace files, audio recorder. |
+| [03-forms-and-fields.md](./03-forms-and-fields.md) | Reusable form controls (`ControlValueAccessor` widgets): editable listbox, relation list, API-key picker, OAuth2 secret, content-selection filter, prompt editor, etc. Plus the i18n/field-translation system. |
+| [04-infrastructure-and-auth.md](./04-infrastructure-and-auth.md) | Login, fast-setup (first-run admin account), user profile, self-service user workflows (activation/forgot-password), user integrations (API keys/MCP), auth interceptor, credentials storage. |
+| [05-dashboards-and-notifications.md](./05-dashboards-and-notifications.md) | LLM usage and workflow-stats dashboards, the toast/notification system. |
+
+## Install
+
+```bash
+npm install @Gebo.ai/reusable-ui
+```
+
+Peer dependencies (must already be present in the consuming app — see `package.json`):
+
+```json
+{
+  "@angular/common": "^21.2.18",
+  "@angular/core": "^21.2.18",
+  "primeng": "^21.1.9",
+  "primeicons": "^7.0.0",
+  "primeflex": "^4.0.0",
+  "@primeng/themes": "^21.0.4",
+  "ng-diagram": "^1.2.4"
+}
+```
+
+This is an Angular **module-based** (non-standalone-by-default) library: every feature is an
+`NgModule` you import, most declaring their inner components as internal and exporting only the
+top-level one. Import the specific feature module(s) you need — importing `GeboUIArchitectureModule`
+alone does not pull in login, chat, dashboards, etc.
+
+## Minimal app wiring
+
+This is the real `AppModule` wiring from this repo (`gebo.ui/src/app/app.module.ts`), trimmed to
+the parts that come from `@Gebo.ai/reusable-ui`:
+
+```ts
+import { HTTP_INTERCEPTORS, HttpClient, provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
+import { BASE_PATH } from '@Gebo.ai/gebo-ai-rest-api';
+import {
+  AuthInterceptor, GeboAIFieldTranslationContainerModule, GeboAIModulesModule,
+  GeboAINotificationsModule, GeboUIArchitectureModule, ApplicationMenuProviderService,
+  GeboUIEntityFormsLauncherService, GeboUIEntityFormsLauncherByInjectionService,
+  GeboUIActionRoutingService, LoginModule, FastSetupModule,
+  GeboAIUserProfileModule, GeboAIUserIntegrationsModule, GeboBackendListService
+} from "@Gebo.ai/reusable-ui";
+
+@NgModule({
+  imports: [
+    LoginModule,
+    FastSetupModule,
+    GeboUIArchitectureModule,          // action routing + modal + entity-forms-launcher + desktop shell
+    GeboAIUserProfileModule,
+    GeboAIUserIntegrationsModule,
+    GeboAINotificationsModule.forRoot(), // MUST be forRoot() exactly once, at the app root
+    GeboAIModulesModule.forRoot(),       // MUST be forRoot() exactly once, at the app root
+    GeboAIFieldTranslationContainerModule.forRoot(), // MUST be forRoot() exactly once, at the app root
+  ],
+  providers: [
+    GeboBackendListService,
+    GeboUIActionRoutingService,
+    { provide: BASE_PATH, useFactory: getBaseUrl }, // your backend base URL
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+    { provide: ApplicationMenuProviderService, useClass: AppMenuProviderService }, // your own top-nav menu
+    { provide: GeboUIEntityFormsLauncherService, useClass: GeboUIEntityFormsLauncherByInjectionService },
+    provideHttpClient(withInterceptorsFromDi()),
+  ]
+})
+export class AppModule {}
+```
+
+Then, once in the root template (typically inside `GeboAIDesktopComponent`'s own template, or
+next to it):
+
+```html
+<gebo-ui-entities-forms-launcher-component></gebo-ui-entities-forms-launcher-component>
+<gebo-ai-display-messages [layer]="'GLOBAL'"></gebo-ai-display-messages>
+```
+
+See [01-architecture.md](./01-architecture.md) for what these two lines actually do.
+
+## Known rough edges worth knowing before you rely on something
+
+- `GeboAIStringListComponent` (`gebo-ai-strings-list-component`) has an unfinished `confirmValue()` — it reads the form array but never propagates the value out via `ControlValueAccessor`. Treat as WIP.
+- `GeboAIPromptWizardComponent`'s `doGeneratePrompt()` body is empty — "AI-assisted prompt generation" isn't wired to a backend call yet.
+- `GaboAIAclSettingsComponent` (`acl-settings-component/`) is a stub with an empty `ngOnInit()`, and — like `editable-multiselect-component`, `view-table`, `web-viewer` — is **not re-exported from `public-api.ts`**, so it isn't importable from the published package even though the source exists.
+- `GeboAIModulesService.getConfig().sharepointModuleEnabled` is derived from the wrong module-id constant internally (reads `SHARED_FILESYSTEM_MODULE` instead of `SHAREPOINT_MODULE`) — don't rely on that one flag.
+- `GeboAITranslableDirective` (`[gebo-translable]`) has no functional implementation yet.

--- a/gebo.ui/projects/gebo-ai-reusable-ui/docs/01-architecture.md
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/docs/01-architecture.md
@@ -1,0 +1,222 @@
+# Architecture: actions, modals, entity forms, wizards
+
+Read [00-overview.md](./00-overview.md) first for the module install/wiring. This doc covers the
+decoupled "request an action → route it → open a modal/form" pipeline that most editing UI in
+this library (and in apps that consume it) is built on, plus the setup-wizard framework.
+
+## 1. The core problem this solves
+
+Any component (a tree node, a table row, a menu item) may need to say "open the editor for this
+entity" or "create a new X" — without knowing which component renders that editor, or where it
+lives in the DOM. This library solves it with a small pub/sub bus:
+
+```
+component fires a GeboUIActionRequest
+        │
+        ▼
+GeboUIActionRoutingService.routeEvent(request)   // finds a registered listener by targetType
+        │
+        ▼
+GeboUIModalOpenerComponent.handleAction(request)  // one instance per entity type, self-registered
+        │
+        ▼
+opens <gebo-ui-modal-wrapper> which dynamically instantiates a BaseEntityEditingComponent subclass
+```
+
+`GeboUIEntityFormsLauncherComponent` (selector `gebo-ui-entities-forms-launcher-component`) is a
+bootstrap component you place once in your app shell. On init it reads every registered
+`GeboUIEntityFormConfig` and materializes one `GeboUIModalOpenerComponent` per entity type — so
+you never place `<gebo-ui-modal-opener>` manually.
+
+## 2. Registering an entity editor
+
+```ts
+import { GEBO_UI_ENTITY_FORM_TOKEN, GeboUIEntityFormConfig } from "@Gebo.ai/reusable-ui";
+
+@NgModule({
+  providers: [
+    {
+      provide: GEBO_UI_ENTITY_FORM_TOKEN,
+      useValue: {
+        entityName: 'GGitSystem',
+        // alternate names the backend may send (e.g. fully-qualified Java class names)
+        entityAliases: ['GGitContentManagementSystem', 'ai.gebo.git.content.handler.GGitContentManagementSystem'],
+        entityUI: GeboAiGitSystemAdminComponent,
+      } as GeboUIEntityFormConfig,
+      multi: true,
+    },
+  ],
+})
+export class MyFeatureModule {}
+```
+
+This is the real pattern used throughout `gebo-ai-admin-ui` (one `{provide: GEBO_UI_ENTITY_FORM_TOKEN, ...}`
+entry per editable entity type — dozens of them in that module). `entityUI` must be a component
+class that extends `BaseEntityEditingComponent<T>` (see §3).
+
+`GeboUIEntityFormsLauncherService` is the abstraction that supplies the list of configs to the
+launcher; the default (and only) implementation, `GeboUIEntityFormsLauncherByInjectionService`,
+just returns everything injected via `GEBO_UI_ENTITY_FORM_TOKEN`. Register it once at the app root:
+
+```ts
+{ provide: GeboUIEntityFormsLauncherService, useClass: GeboUIEntityFormsLauncherByInjectionService }
+```
+
+## 3. Writing an entity-editing component
+
+Extend `BaseEntityEditingComponent<RecordType extends {code?, description?}>`. Real, working
+example from this repo (`gebo-deep-search-admin.component.ts`, trimmed):
+
+```ts
+import { Component, forwardRef, Injector } from "@angular/core";
+import { FormControl, FormGroup } from "@angular/forms";
+import {
+  BaseEntityEditingComponent, GEBO_AI_FIELD_HOST, GEBO_AI_MODULE,
+  GeboFormGroupsService, GeboUIActionRoutingService, GeboUIOutputForwardingService,
+} from "@Gebo.ai/reusable-ui";
+import { ConfirmationService } from "primeng/api";
+import { Observable, of, map } from "rxjs";
+
+@Component({
+  selector: "gebo-ai-deep-search-admin-component",
+  templateUrl: "gebo-deep-search-admin.component.html",
+  standalone: false,
+  providers: [
+    { provide: GEBO_AI_MODULE, useValue: "GeboAIDeepSearchConfigAdminModule" },
+    { provide: GEBO_AI_FIELD_HOST, useExisting: forwardRef(() => GeboAIDeepSearchConfigAdminComponent) },
+  ],
+})
+export class GeboAIDeepSearchConfigAdminComponent extends BaseEntityEditingComponent<DeepSearchConfig> {
+  protected override entityName = "DeepSearchConfig";
+  override formGroup = new FormGroup({
+    code: new FormControl(),
+    description: new FormControl(),
+    // ...rest of the entity's fields
+  });
+
+  constructor(
+    injector: Injector,
+    geboFormGroupsService: GeboFormGroupsService,
+    confirmationService: ConfirmationService,
+    geboUIActionRoutingService: GeboUIActionRoutingService,
+    outputForwardingService: GeboUIOutputForwardingService,
+    private deepSearchConfigService: GeboDeepSearchAdminControllerService, // your own extra deps go after
+  ) {
+    super(injector, geboFormGroupsService, confirmationService, geboUIActionRoutingService, outputForwardingService);
+  }
+
+  override findByCode(code: string): Observable<DeepSearchConfig | null> {
+    return this.deepSearchConfigService.getDeepSearchDefaultConfig();
+  }
+  override save(value: DeepSearchConfig): Observable<DeepSearchConfig> {
+    return this.deepSearchConfigService.updateDeepSearchConfig(value);
+  }
+  override insert(value: DeepSearchConfig): Observable<DeepSearchConfig> {
+    return this.deepSearchConfigService.insertDeepSearchConfig(value);
+  }
+  override delete(value: DeepSearchConfig): Observable<boolean> {
+    return this.deepSearchConfigService.deleteDeepSearchConfig(value).pipe(map(() => true));
+  }
+  override canBeDeleted(value: DeepSearchConfig): Observable<{ canBeDeleted: boolean; message: string }> {
+    return of({ canBeDeleted: true, message: "" });
+  }
+}
+```
+
+Notes:
+- The `GEBO_AI_MODULE` / `GEBO_AI_FIELD_HOST` providers are boilerplate needed by every field that
+  uses `<gebo-ai-field>`/`[gebo-ai-label]`/`[gebo-ai-text]` inside the template — see
+  [03-forms-and-fields.md](./03-forms-and-fields.md#field-translation-container). Copy them verbatim,
+  changing only the module-id string and the component's own class name.
+- Constructor param order for the base class is fixed: `injector, geboFormGroupsService, confirmationService, geboUIActionRoutingService, outputForwardingService`. Extra deps go after.
+- `formGroup` only needs the fields you know about at compile time — `GeboFormGroupsService` will
+  auto-add any additional `FormControl`s the backend declares for `entityName` via metadata (custom/
+  pluggable fields) at runtime, so you don't get "unknown control" errors on those.
+- If deletability is just "call this metadata-check endpoint" rather than custom logic, extend
+  `BaseEntityEditingComponentAutoDeleteCheck<T>` instead — it implements `canBeDeleted` for you via
+  `GeboAngularFormGroupMetaInfoControllerService.checkDeletableBySimpleObjectRef`.
+- Multi-step editors: pass `wizardStepsConfigurations: GeboAIEntitiesSettingWizardConfiguration[]` describing
+  next/previous step navigation (label, icon, and a callback building the next `GeboUIActionRequest`);
+  the base class exposes `nextStep()`/`previusStep()` and the modal wrapper renders the step breadcrumb automatically.
+
+## 4. Firing an action request
+
+From anywhere with `GeboUIActionRoutingService` injected:
+
+```ts
+import { GeboActionType, GeboUIActionRequest } from "@Gebo.ai/reusable-ui";
+
+const request: GeboUIActionRequest = {
+  contextType: "GProject",
+  context: someProject,
+  actionType: GeboActionType.OPEN_OR_NEW,   // NEW | OPEN | OPEN_OR_NEW
+  targetType: "GGitSystem",                  // must match a registered entityName/entityAliases
+  target: undefined,                         // existing entity when actionType is OPEN
+  onActionPerformed: (event) => {
+    // event.actionType: SAVED | DELETED | INSERTED | CLOSING_WINDOW
+  },
+};
+this.geboUIActionRoutingService.routeEvent(request);
+```
+
+## 5. Generic (non-entity) modal
+
+For a plain modal that isn't part of the action-routing pipeline, use `<gebo-ai-modal>` directly:
+
+```html
+<gebo-ai-modal [(visible)]="dialogOpen" header="Confirm" [modal]="true">
+  <p>Are you sure?</p>
+</gebo-ai-modal>
+```
+
+## 6. Setup wizard framework
+
+Used for the guided post-install configuration flow (LLM setup, integrations, etc.). Register
+sections via the `WIZARD_SECTION` multi-provider token:
+
+```ts
+import { WIZARD_SECTION, SetupWizardsSection, AlwaysTrueStatusService } from "@Gebo.ai/reusable-ui";
+
+const mySection: SetupWizardsSection = {
+  orderEntry: 10,
+  wizardSectionId: "my-integration",
+  label: "My Integration",
+  description: "Configure My Integration",
+  enabledService: AlwaysTrueStatusService,       // or your own AbstractStatusService
+  setupCompletedService: MyCompletionCheckService, // an AbstractStatusService you implement
+  wizardComponent: MyWizardStepComponent,          // extends BaseWizardSectionComponent
+  mandatory: true,
+};
+
+@NgModule({ providers: [{ provide: WIZARD_SECTION, useValue: mySection, multi: true }] })
+export class MyModule {}
+```
+
+Your step component:
+
+```ts
+@Component({ selector: "my-wizard-step", template: "..." })
+export class MyWizardStepComponent extends BaseWizardSectionComponent {
+  constructor(setupWizardComunicationService: SetupWizardComunicationService) {
+    super(setupWizardComunicationService);
+  }
+  reloadData(): void { /* fetch current state */ }
+}
+```
+
+Drop `<gebo-setup-wizard-panel-component>` (from `SetupWizardPanelModule`) wherever the wizard UI
+should render; it reads `SetupWizardService.getActualStatus()` (which resolves every registered
+section's `enabledService`/`setupCompletedService`) and renders a step list + the active step's
+`wizardComponent`. Call `.closeWizard()` from inside a step (already available via the base class)
+to return to the section list.
+
+## 7. Base URL validator
+
+```ts
+import { GeboAIValidators } from "@Gebo.ai/reusable-ui";
+new FormControl('', GeboAIValidators.baseUrl(/* required */ true));
+```
+
+See [05-dashboards-and-notifications.md](./05-dashboards-and-notifications.md) for the toast
+notification system (`GeboAINotificationsModule`), which most components above push messages
+into via `userMessages`/`<gebo-ai-notifications [messages]="userMessages">`.

--- a/gebo.ui/projects/gebo-ai-reusable-ui/docs/02-chat-and-knowledge-base.md
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/docs/02-chat-and-knowledge-base.md
@@ -1,0 +1,181 @@
+# Chat, knowledge base & content
+
+All modules below export a single top-level component; internal sub-components exist in the same
+folder but aren't part of the public API surface unless noted.
+
+## Chat widget — `GeboAIReusableChatModule` / `<gebo-ai-reusable-chat-component>`
+
+The full RAG/plain chat UI: send/stream messages, chat history, rename/delete, TTS playback,
+speech-to-text, export to PDF/DOCX, agentic pipeline routing.
+
+```ts
+import { GeboAIReusableChatModule } from "@Gebo.ai/reusable-ui";
+@NgModule({ imports: [GeboAIReusableChatModule] })
+export class MyChatFeatureModule {}
+```
+
+```html
+<gebo-ai-reusable-chat-component
+  [ragsystem]="true"
+  [chatInfo]="currentChat"
+  [title]="currentChat?.description"
+  (updatedChatAction)="onUpdatedChat($event)">
+</gebo-ai-reusable-chat-component>
+```
+(real usage from `gebo-ai-chat-ui`'s `gebo-ai-rag-chat-section.component.html`)
+
+| Input | Type | Notes |
+|---|---|---|
+| `chatInfo` | `GUserChatInfo` | Drives history load. Omit/leave undefined to start a fresh unsaved chat. |
+| `title` / `subtitle` | `string` | Header text. |
+| `modelName` | `string` | Display label for which model is answering. |
+| `ragsystem` | `boolean` | `true` = retrieval-augmented (searches knowledge bases); `false` = plain model chat. |
+| `maxDisplayedDocs` | `number` (default 3) | Cap on referenced-document chips shown per response. |
+| `streamingTimeout` | `number` ms (default 600000) | |
+| `useRestOnly` | `boolean` | Disable SSE streaming, fall back to plain REST round-trip. |
+
+| Output | Payload |
+|---|---|
+| `addedChatAction` | `GUserChatInfo` — fired when a new chat session is created (e.g. first message sent without a prior `chatInfo`) |
+| `updatedChatAction` | `GUserChatInfo` — description renamed etc. |
+| `deleteChatAction` | `GUserChatInfo` |
+| `cancelAction` | `boolean` |
+
+Minimal "test this model" usage (also real, from `gebo-ai-admin-ui`):
+```html
+<gebo-ai-reusable-chat-component [chatInfo]="{chatModelCode: chatModelCode}" [modelName]="chatModelCode">
+</gebo-ai-reusable-chat-component>
+```
+
+Underlying streaming service if you need to talk to the same endpoints directly:
+`ReactiveRagChatService` (`streamChat`, `streamRagChat`, `streamAgenticChat` — all POST + SSE-style
+line-delimited JSON via `fetch`, built on the library's internal `GeboAIBaseStreamingService`).
+
+## Deep search — `GeboAIDeepSearchModule`
+
+Two components, both exported:
+- `<gebo-ai-deep-search-component>` (`GeboAIDeepSearchComponent`) — the deep-search mode panel inside the chat composer (`query`, `knowledgeBases`, `deepSearchDataSources` fields). `[currentChatRequest]`, `[nextRequestMode]="'standard-chat'|'deep-search'"`, `[chatProfileCode]`; `(skipDeepSearchEvent)`.
+- `<gebo-ai-deep-search-sources-choice>` (`GeboAIDeepSearchSoucesChoiceComponent`) — modal to pick which data sources/knowledge bases to search before firing a deep-search request; auto-skips itself if only one choice exists.
+  ```html
+  <gebo-ai-deep-search-sources-choice
+    [(visible)]="showSourcesDialog"
+    [(deepSearchDataSources)]="chosenSources"
+    [(knowledgeBases)]="chosenKbs"
+    [chatProfileCode]="profileCode"
+    (onChoosed)="startDeepSearch($event)"
+    (onSkip)="startDeepSearch()">
+  </gebo-ai-deep-search-sources-choice>
+  ```
+
+## Document viewer — `GeboAIContentViewerModule`
+
+Universal content viewer: source-code (Monaco), plain text, PDF, browsable HTML, or download-only
+fallback, chosen automatically from resolved file type.
+
+```html
+<gebo-ai-content-viewer
+  [code]="documentCode"
+  [activate]="viewerOpen"
+  (close)="viewerOpen = false">
+</gebo-ai-content-viewer>
+```
+`[code]` is a content-controller code (for knowledge-base documents); alternatively pass
+`[userUploadedContent]: EnrichedUserUploadedContentView` or `[generatedContent]: EnrichedLLMGeneratedResource`
+for the other two content sources this viewer understands.
+
+Also exported from this module:
+- `<gebo-ai-code-editor>` (`CodeEditorWrapperComponent`) — standalone Monaco wrapper bound to a `ContentObject`: `[language]`, `[componentHeight]="'100%'"`, `[contentObject]`.
+- `<gebo-ui-document-opener-button>` (`GeboUIDocumentOpenerButton`) — a button/link that opens the viewer above for you: `[document]: EnrichedDocumentReferenceView` / `[uploadedContent]` / `[generatedContent]`.
+- `EnrichedDocumentReferenceViewRetrieveService` — inject this to resolve/enrich document/upload/generated-resource DTOs with file-type + icon before handing them to the components above (`searchByDocumentName`, `findDocumentReferenceViewByCode`, `enrichUserUploadedContent`, `enrichLLMGeneratedResource`).
+
+## Choose documents panel (chat "attached documents") — `GeboAIChooseDocumentsPanelModule`
+
+`<gebo-ai-choose-documents-panel-component>` — the attached-documents chip list used in the chat
+composer; implements `ControlValueAccessor` over `string[]` document codes.
+
+```html
+<gebo-ai-choose-documents-panel-component
+  formControlName="attachedDocs"
+  [knowledgeBaseCodes]="['kb-1']"
+  [maxDisplayedDocuments]="5"
+  (successfullDocumentChosen)="onDocsChosen()">
+</gebo-ai-choose-documents-panel-component>
+```
+
+Also exported: `<gebo-ai-search-documents-component>` (the search dialog content: semantic search
++ filename search + directory browse, `[knowledgeBaseCodes]`, emits `confirmed`/`closeMe`) and
+`<gebo-ai-documents-list-panel-component>` (dumb picklist over an already-fetched
+`DocumentReferenceView[]`, `[documentsList]`, emits `documentsSelection`).
+
+Upload-into-chat widget is a **separate module**, `GeboAIUploadChatDocumentModule`:
+```html
+<gebo-ai-upload-chat-documents-files
+  [(showUpload)]="uploadOpen"
+  [ragChat]="true"
+  [userSessionCode]="currentChat?.code"
+  (successfullUploadDone)="onUploaded()"
+  (newSessionCreatedOnUpload)="onNewSession($event)">
+</gebo-ai-upload-chat-documents-files>
+```
+
+## Virtual filesystem browser — `VFilesystemSelectorModule`
+
+Generic tree browser/picker over *any* backend "virtual filesystem" (git, SharePoint, Google Drive,
+uploads, userspace, knowledge-base trees). You supply the data-fetching callbacks; the component
+only renders the PrimeNG tree + selection + edit-dialog UI.
+
+```html
+<gebo-ai-vfilesystem-selector-component
+  formControlName="chosenPath"
+  [selectionMode]="'single'"
+  [canChooseFolders]="true"
+  [canChooseFiles]="true"
+  [loadRootsObservable]="loadRoots"
+  [browsePathObservable]="browsePath">
+</gebo-ai-vfilesystem-selector-component>
+```
+```ts
+loadRoots = () => this.myService.getRoots();          // Observable<VFilesystemRootsResponse>
+browsePath = (param: BrowseParam) => this.myService.list(param); // Observable<VFilesystemListPathInfo>
+```
+Value type (via `ControlValueAccessor`) is `VFilesystemReference | VFilesystemReference[]`
+(`{ root: GVirtualFilesystemRoot, path?: PathInfo }`).
+
+## Browse external content — `BrowseContentModule`
+
+`<gebo-ai-browse-content-component>` — plain `<iframe [src]="url">` wrapper: `[title]`, `[url]`.
+`<gebo-ai-html-viewer-component>` (`GeboAIViewHtmlComponent`) — injects a raw HTML string via `[htmlCode]`.
+
+## Userspace files ("attach my personal files") — `GeboAIUserspaceFilesModule`
+
+`<gebo-ai-userspace-files-component>` — picker for a user's personal uploaded files, implementing
+`ControlValueAccessor` over `string[]` file codes.
+```html
+<gebo-ai-userspace-files-component formControlName="attachedUserFiles" [knowledgeBaseCodes]="['kb-1']">
+</gebo-ai-userspace-files-component>
+```
+This module also self-registers editors for `UserspaceFolderDto` and `UserspaceKnowledgebaseDto`
+into the [entity-forms-launcher](./01-architecture.md) registry (via `GeboUIEntityFormsLauncherService`),
+so "new folder"/"new personal knowledge base" actions fired anywhere in the app resolve automatically.
+
+## Audio recorder — `GeboAIAudioRecorderModule`
+
+`<gebo-ai-audio-component>` — mic recorder + player (handles Safari/iOS MIME fallbacks internally).
+```html
+<gebo-ai-audio-component [disabled]="false" (onAudioTrack)="onRecorded($event)"></gebo-ai-audio-component>
+```
+`errorReason` (when `errorState` is true) is one of
+`'permission-denied' | 'no-device' | 'device-busy' | 'insecure-context' | 'unsupported' | 'unknown'`.
+
+## Adding a new project data-source type — `ProjectAddContextMenuModule`
+
+`<project-add-context-menu>` (`ProjectAddContextMenuComponent`) renders the "+ add" menu (buttons,
+menu items, or full page) for adding sub-projects / data sources / modules to a `GProject`, sourced
+from whatever [pluggable project-endpoint modules](./03-forms-and-fields.md) are installed.
+```html
+<project-add-context-menu [data]="project" [showAsButtons]="true" (refreshUIEvent)="reload()">
+</project-add-context-menu>
+```
+Also exported from the same module: `<gebo-ui-choose-data-source-type-component>`
+(`GeboAIChooseDataSourceTypeComponent`) — the first step of that "add data source" wizard, an
+entity-editing component (extends `BaseEntityEditingComponent`) capturing which source type was chosen.

--- a/gebo.ui/projects/gebo-ai-reusable-ui/docs/03-forms-and-fields.md
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/docs/03-forms-and-fields.md
@@ -1,0 +1,146 @@
+# Reusable form controls & the i18n field system
+
+Almost every control here implements Angular's `ControlValueAccessor` — use them with
+`formControlName`/`[(ngModel)]`, not raw `@Input`/`@Output` pairs, unless stated otherwise.
+
+## Field translation container — the i18n wrapper used everywhere
+
+`GeboAIFieldTranslationContainerModule` (import with `.forRoot()` **once**, at the app root — see
+[00-overview.md](./00-overview.md)) provides the label/help/placeholder translation plumbing that
+wraps nearly every form field in the app.
+
+```html
+<div [formGroup]="formGroup">
+  <gebo-ai-field id="code" label="Code" help="Unique identifier">
+    <input gebo-ai-field-element pInputText formControlName="code" />
+  </gebo-ai-field>
+</div>
+```
+`<gebo-ai-field>` (`gebo-ai-field`) requires `[id]` and `[label]` (both `@Input({required:true})`),
+optional `[placeholder]`, `[help]`, `[required]`. It must sit inside a `[formGroup]`/`FormGroupDirective`
+context. The `gebo-ai-field-element` directive on the inner input auto-wires `id`/`aria-describedby`/
+`required`/`aria-invalid` from the field container + the input's own `NgControl`.
+
+For plain (non-form) translated text, use the directives directly:
+```html
+<label gebo-ai-label>Some label</label>
+<span gebo-ai-text>Some UI text</span>
+<p-button gebo-ai-label label="Save"></p-button> <!-- 22 PrimeNG components have adapter support -->
+```
+`[gebo-ai-label]` works on plain DOM elements' `label`/`legend`/`header`/`title`/`placeholder`
+attributes, and on 22 specific PrimeNG components (button, dialog, panel, card, chip, tag, checkbox,
+radio, select, multiselect, listbox, calendar, slider, etc.) via dedicated adapter directives,
+because those components' "label" isn't a plain DOM attribute.
+
+Every component that hosts `<gebo-ai-field>`/`[gebo-ai-label]`/`[gebo-ai-text]` children must
+provide two DI tokens so those children can resolve translation lookup keys:
+```ts
+providers: [
+  { provide: GEBO_AI_MODULE, useValue: "MyFeatureModule" },   // arbitrary but stable module id
+  { provide: GEBO_AI_FIELD_HOST, useExisting: forwardRef(() => MyComponent) }, // or fieldHostComponentName("MyEntity")
+]
+```
+`fieldHostComponentName(entityName: string)` is a shortcut when you don't need dynamic host
+resolution: `{ provide: GEBO_AI_FIELD_HOST, useValue: fieldHostComponentName("MyEntity") }`.
+
+Language switcher: `<gebo-ai-language-choice-component>` (CVA, value = language code string).
+App-header variant: `<gebo-ai-main-language-choice [menuItem]="langMenuItem">` (persists to
+`localStorage['gebo.ai.lang']`, defaults to browser language if supported).
+
+## Editable listbox / relation list — pick-or-create-new widgets
+
+`EditableListboxModule`:
+```html
+<geboai-editable-listbox-component
+  formControlName="chosenCode"
+  [optionsObservable]="options$"
+  [createNewRecordRequest]="newRecordRequest">
+</geboai-editable-listbox-component>
+```
+Value is the item's `code` (`string`). `createNewRecordRequest?: GeboUIActionRequest` — when set, an
+extra "Create new…" option appears that fires this request through
+[the action-routing pipeline](./01-architecture.md#4-firing-an-action-request). Sibling
+`<geboai-editable-listbox-bound-object-component>` (`EditableListboxBoundObjectAdapterComponent`)
+does the same but binds/emits the **full `{code,description}` object** instead of just the code.
+
+`GeboAiRelationListModule`: `<gebo-ai-relation-list formControlName="relatedCodes" [allOptionsObservable]="all$" [remainingObjectsObservable]="remaining$">` — chip-list editor for a many-to-many
+relation; value is `string[]` of codes.
+
+## Content selection filter — `GeboAIContentSelectionFilterModule`
+
+`<gebo-ai-content-selection-filter-component formControlName="filter" title="File selection criterias">`
+— editable list of ingestion-scoping rules (mime types, extensions, name filter+operator, max file
+size/token size/modification age). Value: `GContentSelectionFilter = { criterias: GContentSelectionFilterCriteria[] }`.
+Implements `Validator` as well as CVA — invalid rows surface as form errors automatically.
+
+## API key / secret picker — `GeboAIApiKeyModule`
+
+```html
+<gebo-ai-api-key-component
+  formControlName="secretCode"
+  [contextCode]="'git-endpoint-123'"
+  [apiKeyDescription]="'Git access token'"
+  [backendValidation]="validateFn">
+</gebo-ai-api-key-component>
+```
+`contextCode` and `apiKeyDescription` are `@Input({required:true})`. `backendValidation?: (credentials: SecretInfo) => Observable<IOperationStatus<any>>`
+— if the newly-entered secret fails this check, the component deletes the credential server-side and
+surfaces the validation error. Value: secret `code: string | undefined`.
+
+## OAuth2 secret editor — `GeboOauth2SecretModule`
+
+`<gebo-ui-oauth2-secret-component formControlName="oauthSecret" [oauth2ChoosableScopes]="scopes">` —
+`clientId`/`secret`/`scopes` plus dynamically-generated custom attribute fields per selected provider.
+`[hideProviderChoice]`, `[forcedProviderName]` to pin a single provider. Implements both CVA and
+`Validator` (`notValidated`/`required`/`requiredFields` errors while provider metadata is loading).
+
+## Choose LLM tool-calling functions — `GeboAIChooseLLMFunctionsModule`
+
+`<gebo-ai-choose-llm-functions-component formControlName="enabledFunctions" [knowledgeBaseContext]="true">`
+— `p-treeSelect` over the backend's tool/function catalog. Value: `string[]` (leaf function names).
+
+## Chat model "used for" flags — `GeboAIChatModelUseModule`
+
+`<gebo-ai-chat-model-use-component formControlName="forUses">` — checkbox group, value:
+`GBaseChatModelConfig.ForUsesEnum[]` (`CHAT` / `INTERNAL_SERVICES`).
+
+## Prompt template editor — `PromptEditingModule`
+
+`<gebo-ai-prompt-editing-component formControlName="promptText" [rows]="8" [placeHolders]="[{code:'{{query}}', description:'User query', required:true}]">`
+— Monaco-backed editor for prompt templates; value is the raw `string`. (Note: the sibling
+"AI-assisted prompt generation" wizard dialog exists in the same folder but its generation call
+isn't wired up yet — see [00-overview.md](./00-overview.md#known-rough-edges).)
+
+## Reindex schedule editor — `GeboAIContentReindexModule`
+
+`<gebo-ai-content-reindex-scheduler-component formControlName="schedule" [frequencyTypes]="['DAILY','WEEKLY']">`
+— add/edit/remove UI for a set of `ReindexingProgrammedTable` rules. Value: `ReindexingProgrammedTable[]`.
+
+## Base entity-editing infrastructure
+
+See [01-architecture.md §3](./01-architecture.md#3-writing-an-entity-editing-component) for
+`BaseEntityEditingComponent<T>` / `BaseEntityEditingComponentAutoDeleteCheck<T>` — the CRUD base
+classes most "entity edit form" components in this library (and in `gebo-ai-admin-ui`) extend.
+
+## Pluggable project-endpoint modules (extension point)
+
+If you're adding a new data-source type (a new "Git"/"SharePoint"-like integration), implement
+`GeboAIPluggableProjectEndpointModuleService` and register it:
+```ts
+{
+  provide: GEBO_AI_PLUGGABLE_MODULE_UI_CONFIG,
+  useValue: {
+    moduleId: 'MY_MODULE',
+    projecteEndpointClassName: 'ai.myorg.MyProjectEndpoint',
+    addProjectEndpointicon: 'pi pi-cloud',
+    addProjectEndpointLabel: 'My Source',
+    addProjectEndpointTitle: 'Add My Source',
+    service: MyProjectEndpointModuleService,
+  } as GeboAIPluggableProjectEndpointModule,
+  multi: true,
+}
+```
+`GeboAIPluggableProjectEndpointsService` aggregates every registered module's
+`findByProjectEndpoints`/`byProjectCreateAction` so the generic knowledge-base tree UI
+(`ProjectAddContextMenuModule`, see [02-chat-and-knowledge-base.md](./02-chat-and-knowledge-base.md))
+picks it up automatically without core-library changes.

--- a/gebo.ui/projects/gebo-ai-reusable-ui/docs/04-infrastructure-and-auth.md
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/docs/04-infrastructure-and-auth.md
@@ -1,0 +1,103 @@
+# Login, setup, users & auth infrastructure
+
+## First-run admin setup — `FastSetupModule`
+
+`<gebo-ai-fast-setup>` — creates the first admin account + accepts the licence agreement. Routed
+internally at `ui/setup`. No inputs; self-contained.
+
+## Login — `LoginModule`
+
+Import once at the app root. Registers routes `ui/login`, `ui/oauth2-land`, `ui/logged`,
+`ui/logout`, `ui/reloader`; exports only `<gebo-ai-login-component>` (`gebo-ai-login-component`) for
+direct use, the rest are internal route targets.
+
+```ts
+import { LoginModule } from "@Gebo.ai/reusable-ui";
+@NgModule({ imports: [LoginModule] })
+export class AppModule {}
+```
+
+`LoginService` (`providedIn: 'root'`) is the service backing it — inject it wherever you need
+current-session state:
+```ts
+constructor(private loginService: LoginService) {
+  this.loginService.logged.subscribe(userInfo => { /* userInfo: UserInfo | undefined */ });
+}
+```
+Key methods: `login({username, password})`, `logout()`, `loadUserProfile()`, `changePassword(...)`,
+`getOauth2LoginOptions()`, `loginWithOauth2(...)`. It also self-schedules a JWT-renewal poll every
+60s while credentials exist — you don't need to call anything to keep the session alive.
+
+## Auth wiring (required for any authenticated backend call)
+
+```ts
+import { AuthInterceptor, GeboBackendListService } from "@Gebo.ai/reusable-ui";
+import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
+
+providers: [
+  GeboBackendListService,                 // registers your BASE_PATH as "a Gebo backend" automatically
+  { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+  provideHttpClient(withInterceptorsFromDi()),
+]
+```
+`AuthInterceptor` attaches the stored auth header to any request whose URL is a known Gebo backend
+(per `GeboBackendListService.isGeboBackend`) and isn't a registered "public" URL; on `401` it clears
+auth and redirects to `/ui/login`; on `500` it pops a PrimeNG confirm dialog pointing users to
+`assistence@gebo.ai`.
+
+`gebo-credentials.ts` is the low-level storage layer underneath `LoginService`/`AuthInterceptor` —
+`getAuth()`, `getAuthHeader()`, `saveAuth(value)`, `resetAuth()` — persisted to `localStorage` under
+key `gebo.ai.credentials`. Use it directly only if you're writing a custom HTTP call outside the
+generated REST clients and need the same bearer header.
+
+If a feature module talks to a **second** Gebo microservice base URL, register it so the
+interceptor still attaches auth headers:
+```ts
+constructor(backends: GeboBackendListService) {
+  backends.addBackendServicesBaseUrl('https://my-other-service.internal');
+  backends.addBackendServicesPublicUrl('/api/public/health'); // relative, no-auth endpoint
+}
+```
+
+## Current user profile — `GeboAIUserProfileModule`
+
+`<gebo-ai-current-user-profile>` (`gebo-ai-current-user-profile`) — displays the logged-in user's
+profile, includes a "change password" dialog internally. No inputs; loads via `LoginService.loadUserProfile()`.
+
+## Self-service activation / forgot-password — `GeboAIUserWorkflowsModule`
+
+Lazy-load the whole module as a route (used exactly this way in this repo's `app.module.ts`):
+```ts
+{ path: 'ui/user-workflows', loadChildren: () => import('@Gebo.ai/reusable-ui').then(m => m.GeboAIUserWorkflowsModule) }
+```
+Or use the two exported components directly:
+- `<gebo-ai-user-start-workflows>` — request form (email + type: `ACTIVATION` | `FORGOTPASSWORD`), gated by server config (`UserWorkflowsControllerService.getUserWorkflowsConfig()`).
+- `<gebo-ai-user-land-workflows>` — consumes the emailed ticket (from route/query param `ticket`), sets the new password, auto-redirects to `/ui/login` after success.
+
+## User integrations (self-service API keys / MCP) — `GeboAIUserIntegrationsModule`
+
+`<gebo-ai-user-integrations>` — lets a logged-in user see which MCP servers they can access and
+manage their own generated API keys (create with expiration preset, list, delete). No inputs;
+gated internally by two feature-flag checks. Routed at `ui/user-integrations`.
+
+## App shell — `GeboUIArchitectureModule` → `<gebo-ai-desktop>`
+
+`GeboAIDesktopComponent` (`gebo-ai-desktop`) is the top app-chrome: mega-menu + auth state. Menu
+content is supplied by your own implementation of the abstract `ApplicationMenuProviderService`:
+```ts
+@Injectable()
+export class AppMenuProviderService extends ApplicationMenuProviderService {
+  getMenuItems(userInfo?: UserInfo): Observable<MegaMenuItem[]> { /* return your nav */ }
+}
+// providers: [{ provide: ApplicationMenuProviderService, useClass: AppMenuProviderService }]
+```
+```html
+<gebo-ai-desktop [version]="'1.0.0'"></gebo-ai-desktop>
+```
+It's `@Optional()`-injected inside `GeboAIDesktopComponent`, so omitting the provider just yields an
+empty menu rather than an error.
+
+## Setup wizard panel
+
+Covered in [01-architecture.md §6](./01-architecture.md#6-setup-wizard-framework) — this is where
+first-run/ongoing configuration sections (LLM providers, integrations, etc.) get registered and rendered.

--- a/gebo.ui/projects/gebo-ai-reusable-ui/docs/05-dashboards-and-notifications.md
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/docs/05-dashboards-and-notifications.md
@@ -1,0 +1,72 @@
+# Dashboards & notifications
+
+## Notifications (toasts) — `GeboAINotificationsModule`
+
+Import with `.forRoot()` **exactly once**, at the app root — it provides PrimeNG's `MessageService`
+singleton:
+```ts
+imports: [GeboAINotificationsModule.forRoot()]
+```
+Feature modules elsewhere just import the plain `GeboAINotificationsModule` (no `forRoot()`) if
+they need the components below.
+
+Place a sink once in the app shell (global layer) and once per modal host if you open dialogs
+above which toasts still need to render:
+```html
+<gebo-ai-display-messages [layer]="'GLOBAL'"></gebo-ai-display-messages>
+<!-- inside a dialog template: -->
+<gebo-ai-display-messages [layer]="'DIALOG'"></gebo-ai-display-messages>
+```
+`NotificationLayerEnum = 'GLOBAL' | 'DIALOG'` — `DIALOG` toasts get a computed z-index above any
+currently-open PrimeNG dialog/overlay (handled internally by `ToastZIndexService`).
+
+Most feature components in this library expose a `userMessages: ToastMessageOptions[]` (or
+`GUserMessage[]`) array — wire it to the forwarder:
+```html
+<gebo-ai-notifications [messages]="userMessages" [layer]="'GLOBAL'"></gebo-ai-notifications>
+```
+`<gebo-ai-notifications>` is headless (no visible template) — it just diffs `messages` on change and
+forwards new entries to `GeboAIRootNotificationService.addMessages(...)`, which translates them
+(via `GeboAITranslationService`) before they reach `<gebo-ai-display-messages>`.
+
+To push a toast programmatically instead:
+```ts
+constructor(private notify: GeboAIRootNotificationService) {}
+this.notify.addMessage('MyModule', 'MyEntity', { severity: 'success', summary: 'Saved' });
+```
+
+## LLM usage dashboards — `GeboAILLMSUsageDashboardModule`
+
+Two components, no inputs on either — scoping (which user's data) is determined entirely by which
+component you use, not by a bound `@Input`:
+
+```html
+<!-- sees ALL users' LLM traffic; filter dropdown includes a "username" dimension -->
+<gebo-ai-llms-usage-admin-dashboard></gebo-ai-llms-usage-admin-dashboard>
+
+<!-- implicitly scoped to the current authenticated user by the backend -->
+<gebo-ai-llms-usage-user-dashboard></gebo-ai-llms-usage-user-dashboard>
+```
+
+Each renders two tabs ("This month, daily" and "Monthly history") with Chart.js token-consumption
+and latency charts, plus per-tab dropdown filters (`providerId`, `username` [admin only], `model`,
+`callerStack`, `modelType`, `year`, `month`) whose options come pre-computed from the backend
+response — there is no free-form date-range picker.
+
+## Workflow stats dashboard — `GeboAIWorkflowStatsDashboardModule`
+
+Only an admin variant exists (no user-level component/service in this library):
+```html
+<gebo-ai-workflow-stats-admin-dashboard></gebo-ai-workflow-stats-admin-dashboard>
+```
+Same two-tab/filter shape as the LLM dashboard, but dimensions are
+`knowledgeBaseReference`, `projectReference`, `projectEndpointReference`, `workflowType`,
+`workflowId`, `workflowStepId`, `year`, `month`, and charts are "Documents" (input/processed/sent/
+discarded/errors) and "Chunks & Tokens" processed.
+
+Both dashboard families share one abstract base (`BaseLLMSUsageDashboardComponent` /
+`BaseWorkflowStatsDashboardComponent`, both `@Directive()`) that does all chart-building/filtering;
+the concrete components only differ in which backend controller they call
+(`LlmsUsageAdminLevelControllerService` vs `LlmsUsageUserLevelControllerService` vs
+`WorkflowStatsAdminLevelControllerService`). If you need a dashboard scoped some other way, subclass
+the relevant base and implement `executeDrillDown(filter)`.

--- a/gebo.ui/projects/gebo-ai-reusable-ui/llms.txt
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/llms.txt
@@ -1,0 +1,26 @@
+# @Gebo.ai/reusable-ui
+
+> Angular 21 (module-based, PrimeNG-based) UI component library for Gebo.ai: chat widget,
+> knowledge-base browsing/ingestion controls, admin entity-editing forms, login/setup, and usage
+> dashboards. Consumed both internally (by `@Gebo.ai/gebo-ai-chat-ui` and `@Gebo.ai/gebo-ai-admin-ui`)
+> and by third-party apps embedding Gebo.ai UI. This file, and the docs it links to, are written for
+> a coding assistant wiring up or extending this library — they give real selectors, `@Input`/`@Output`
+> names, and wiring copied from this repo's own usage, not idealized snippets.
+
+Start with `docs/00-overview.md` for install + minimal app wiring, then `docs/01-architecture.md`
+before anything else — almost every editing/modal feature in this library depends on the
+action-routing/entity-form pipeline explained there.
+
+## Docs
+
+- [docs/00-overview.md](./docs/00-overview.md): Install, peer dependencies, minimal `NgModule` wiring (real example from this repo's `app.module.ts`), and a list of known incomplete/WIP components worth checking before you rely on them.
+- [docs/01-architecture.md](./docs/01-architecture.md): The `GeboUIActionRequest` → `GeboUIActionRoutingService` → modal → `BaseEntityEditingComponent` pipeline; how to register and write entity editors; the setup-wizard framework; generic modals; the base-URL validator.
+- [docs/02-chat-and-knowledge-base.md](./docs/02-chat-and-knowledge-base.md): `<gebo-ai-reusable-chat-component>`, deep search, document viewer, document/userspace-file pickers, virtual-filesystem tree browser, audio recorder, "add data source" menu.
+- [docs/03-forms-and-fields.md](./docs/03-forms-and-fields.md): `ControlValueAccessor` form widgets (editable listbox, relation list, API-key/OAuth2-secret pickers, content-selection filter, prompt editor, reindex schedule) and the `<gebo-ai-field>` i18n/translation wrapper system.
+- [docs/04-infrastructure-and-auth.md](./docs/04-infrastructure-and-auth.md): Login, first-run fast-setup, `AuthInterceptor`/`GeboBackendListService` auth wiring, user profile, self-service activation/forgot-password workflows, user-managed API keys/MCP access, the app shell (`<gebo-ai-desktop>`).
+- [docs/05-dashboards-and-notifications.md](./docs/05-dashboards-and-notifications.md): Toast notification system (`GeboAINotificationsModule`), LLM-usage dashboards (admin vs. user scoped), workflow-stats dashboard.
+
+## Optional
+
+- [README.md](./README.md): Angular CLI scaffolding boilerplate (build/publish/test commands) — not feature documentation.
+- [package.json](./package.json): Peer dependency versions.

--- a/gebo.ui/projects/gebo-ai-reusable-ui/ng-package.json
+++ b/gebo.ui/projects/gebo-ai-reusable-ui/ng-package.json
@@ -7,6 +7,8 @@
   "assets": [
     "./src/assets",
     "./src/styles",
-    "./src/styles.scss"
+    "./src/styles.scss",
+    "./docs",
+    "./llms.txt"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `docs/00-overview.md` through `docs/05-dashboards-and-notifications.md` to `gebo-ai-reusable-ui`, covering the action-routing/entity-form architecture, chat & knowledge-base controls, reusable form widgets + i18n system, login/auth infrastructure, and usage dashboards — all grounded in this repo's real wiring (`app.module.ts`, `gebo-ai-admin-ui` entity registrations).
- Adds a root `llms.txt` index following the [llms.txt convention](https://llmstxt.org/) so a coding assistant/agent can quickly discover the docs.
- Wires `docs/` and `llms.txt` into `ng-package.json` `assets`, so both ship inside the compiled npm package (verified via `ng build` + `npm pack --dry-run`).

## Test plan
- [x] `ng build gebo-ai-reusable-ui` succeeds
- [x] `npm pack --dry-run` from `dist/gebo-ai-reusable-ui` shows `docs/*.md` and `llms.txt` included in the tarball contents
- [x] `dist/` output is gitignored, so no build artifacts are part of this PR's diff