### PR TITLE
fix: WebDAV ingestion silently drops content due to missing extension

### DIFF
--- a/gebo.architecture.parent/gebo.architecture.contenthandling.interfaces/src/main/java/ai/gebo/architecture/contenthandling/interfaces/impl/GDocumentReferenceFactoryImpl.java
+++ b/gebo.architecture.parent/gebo.architecture.contenthandling.interfaces/src/main/java/ai/gebo/architecture/contenthandling/interfaces/impl/GDocumentReferenceFactoryImpl.java
@@ -49,11 +49,22 @@ public class GDocumentReferenceFactoryImpl implements IGDocumentReferenceFactory
 	 * @return the file extension as a string, or null if no extension is found.
 	 */
 	protected String getExtension(Path file) {
-		String name = file.getFileName().toString();
+		return getExtension(file.getFileName().toString());
+	}
+
+	/**
+	 * Extracts and returns the file extension from the given file name.
+	 *
+	 * @param name the file name whose extension is to be retrieved.
+	 * @return the file extension as a string, or null if no extension is found.
+	 */
+	protected String getExtension(String name) {
 		String extension = null;
-		int lastPointPosition = name.lastIndexOf(".");
-		if (lastPointPosition >= 0) {
-			extension = name.substring(lastPointPosition).toLowerCase();
+		if (name != null) {
+			int lastPointPosition = name.lastIndexOf(".");
+			if (lastPointPosition >= 0) {
+				extension = name.substring(lastPointPosition).toLowerCase();
+			}
 		}
 		return extension;
 	}
@@ -277,7 +288,7 @@ public class GDocumentReferenceFactoryImpl implements IGDocumentReferenceFactory
 		reference.setAbsolutePath(null);
 		reference.setCode(spaceFolder.getCode() + "/" + code);
 		reference.setContentType(contentType);
-		reference.setExtension(null);
+		reference.setExtension(getExtension(name));
 		reference.setFileSize(0l);
 		reference.setName(name);
 		reference.setRelativePath(spaceFolder.getRelativePath() + "/" + name);

--- a/gebo.system.ingestion/src/main/java/ai/gebo/system/ingestion/msformats/impl/MSWordIngestionHandler.java
+++ b/gebo.system.ingestion/src/main/java/ai/gebo/system/ingestion/msformats/impl/MSWordIngestionHandler.java
@@ -215,15 +215,39 @@ public class MSWordIngestionHandler extends GAbstractConfiguredHandler {
      * @throws GeboIngestionException If there's an error during ingestion
      * @throws IOException If there's an error reading the input stream
      */
+	private static final String DOCX_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+	private static final String DOC_CONTENT_TYPE = "application/msword";
+
+	/**
+	 * Documents from remote/web content systems (WebDAV, MCP, Git, ...) are built
+	 * via {@code createWebDocumentReference}, which never populates the file
+	 * extension - only the content type is reliably known there. Dispatch to this
+	 * handler already happened by content-type match, so fall back to it whenever
+	 * the extension is unavailable instead of silently dropping the document.
+	 */
+	private static boolean isDocx(GDocumentReference reference) {
+		if (reference.getExtension() != null) {
+			return reference.getExtension().equalsIgnoreCase(".docx");
+		}
+		return DOCX_CONTENT_TYPE.equalsIgnoreCase(reference.getContentType());
+	}
+
+	private static boolean isDoc(GDocumentReference reference) {
+		if (reference.getExtension() != null) {
+			return reference.getExtension().equalsIgnoreCase(".doc");
+		}
+		return DOC_CONTENT_TYPE.equalsIgnoreCase(reference.getContentType());
+	}
+
 	@Override
 	public Stream<Document> handleContent(GDocumentReference reference, InputStream is, Map<String, Object> metadata)
 			throws GeboIngestionException, IOException {
 		List<Document> outlist = new ArrayList<Document>();
 		enrichMetaData(reference, metadata);
-		if (reference.getExtension() != null && reference.getExtension().equalsIgnoreCase(".docx")) {
+		if (isDocx(reference)) {
 			// Process DOCX document
 			return streamDOCXContent(is, metadata);
-		} else if (reference.getExtension() != null && reference.getExtension().equalsIgnoreCase(".doc")) {
+		} else if (isDoc(reference)) {
 			// Process DOC document
 			return streamDOCContent(is, metadata);
 		}


### PR DESCRIPTION
## Summary
- `createWebDocumentReference` (used by every remote content system - WebDAV, Git, MCP, ...) always left `extension` `null`, since only content type is reliably known for remote resources.
- Two extension-only consumers silently broke as a result:
  - `MSWordIngestionHandler.handleContent()` matched neither the `.doc` nor `.docx` branch, returning an empty document stream with no error/log - the chunker then discarded the file as "empty", dropping WebDAV `.docx` content before it ever reached the chunker.
  - `GAIDocumentCatalogingEnricherImpl.getFileType()` looked up its file-type map by extension only, so remote documents never matched and got an empty metadata header, failing the "AI documents without meta header" check for every chunk (including PDF).
- Root-caused via `WebdavIngestionIntegrationTest` (testcontainers-backed, real WebDAV server + fake LLMs): discovery found 2 files but tokenization discarded 1; after fixing that, the metadata-header assertion then failed for the remaining PDF chunks too - both traced back to the same null extension.

## Fix
- Derive the extension from the resource name in `createWebDocumentReference`, mirroring the existing local-file logic (`GDocumentReferenceFactoryImpl`).
- Harden `MSWordIngestionHandler` to fall back to content type when extension is still unavailable, since dispatch to it already happens via content-type match upstream.

## Test plan
- [x] `WebdavIngestionIntegrationTest` (new testcontainers integration test: real `bytemark/webdav` container + fake LLMs, ingests a PDF and a DOCX over WebDAV) passes end-to-end: both documents chunked, embedded, and metadata-enriched.
- [x] Verified manually in the browser: created a WebDAV system + project endpoint against the same container via the admin UI and ran ingestion.