### PR TITLE
fix: WebDAV fast-config credential rollback + auth-type UX fixes

### DIFF
--- a/dockers/lib-multiplatform-images.sh
+++ b/dockers/lib-multiplatform-images.sh
@@ -14,7 +14,14 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-VERSION="1.0.2.2"
+# Read the project's own <version> from the root pom.xml header, stopping at
+# <parent> so we don't accidentally match spring-boot-starter-parent's version
+# instead. Keeps this script aligned with whatever the actual build produces.
+VERSION="$(sed -n '/<parent>/q;p' "$REPO_ROOT/pom.xml" | grep -oP '(?<=<version>)[^<]+(?=</version>)' | head -1)"
+if [ -z "$VERSION" ]; then
+  echo "ERROR: Could not read project version from $REPO_ROOT/pom.xml"
+  exit 1
+fi
 PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
 JAR="$REPO_ROOT/gebo.apps.parent/gebo.ai.app/target/gebo.ai.app-${VERSION}-bootable.jar"
 SBOM="$REPO_ROOT/gebo.apps.parent/gebo.ai.app/target/classes/META-INF/sbom/application.cdx.json"

--- a/gebo.systems.parent/gebo.webdav-cms.handler/src/main/java/ai/gebo/webdavcms/handler/controllers/WebdavSystemsController.java
+++ b/gebo.systems.parent/gebo.webdav-cms.handler/src/main/java/ai/gebo/webdavcms/handler/controllers/WebdavSystemsController.java
@@ -186,6 +186,7 @@ public class WebdavSystemsController
 	@PostMapping(value = "fastWebdavConfig", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 	public OperationStatus<GWebdavContentManagementSystem> fastWebdavConfig(
 			@Valid @RequestBody FastWebdavSystemInsertRequest data) {
+		String secretId = null;
 		try {
 			AbstractGeboSecretContent secret = null;
 			GWebdavContentManagementSystem system = new GWebdavContentManagementSystem();
@@ -216,7 +217,7 @@ public class WebdavSystemsController
 
 			if (secret != null) {
 				String secretDescription = data.authType.name() + " WebDAV system secret";
-				String secretId = secretAccessService.storeSecret(secret, secretDescription,
+				secretId = secretAccessService.storeSecret(secret, secretDescription,
 						WebdavContentManagementHandlerImpl.WEBDAB_CMS);
 				system.setSecretCode(secretId);
 			}
@@ -228,14 +229,24 @@ public class WebdavSystemsController
 
 			OperationStatus<GWebdavContentManagementSystem> status = webdavTestService.testWebdavSystem(system);
 			if (status.isHasErrorMessages()) {
+				if (secretId != null) {
+					secretAccessService.deleteSecret(secretId);
+				}
 				return status;
 			}
 			system = persistentObjectManager.insert(system);
 			return OperationStatus.of(system);
 		} catch (Throwable th) {
 			LOGGER.error("Error trying inserting WebDAV system configuration", th);
+			if (secretId != null) {
+				try {
+					secretAccessService.deleteSecret(secretId);
+				} catch (Throwable deleteError) {
+					LOGGER.error("Failed to roll back WebDAV secret {} after insert error", secretId, deleteError);
+				}
+			}
 			OperationStatus<GWebdavContentManagementSystem> os = new OperationStatus<GWebdavContentManagementSystem>();
-			os.getMessages().add(GUserMessage.errorMessage("Cannot access WebDAV", ""));
+			os.getMessages().add(GUserMessage.errorMessage("Cannot access WebDAV", th));
 			return os;
 		}
 	}

--- a/gebo.ui/projects/gebo-ai-admin-ui/src/lib/admin-ui/entity-editors/gebo-ai-webdav-client-admin/gebo-ai-webdav-system-fast.component.html
+++ b/gebo.ui/projects/gebo-ai-admin-ui/src/lib/admin-ui/entity-editors/gebo-ai-webdav-client-admin/gebo-ai-webdav-system-fast.component.html
@@ -25,10 +25,18 @@
         </gebo-ai-field>
       </div>
       <div class="col-6">
-        <gebo-ai-field id="authType" label="Authentication method" [required]="true" help="Select the authentication method used by the WebDAV server">
+        <gebo-ai-field id="authType" label="Authentication method" [required]="true" help="Select the authentication method used by the WebDAV server. See known compatible systems below.">
           <geboai-editable-listbox-component id="authType" formControlName="authType" [required]="true" placeholder="Select authentication method" class="col-12 required" [data]="authTypes" gebo-ai-field-element>
           </geboai-editable-listbox-component>
         </gebo-ai-field>
+      </div>
+
+      <div class="col-12">
+        <small class="geboAuthTypeSystemsLegend">
+          @for (t of authTypes; track t.code) {
+            <div><strong>{{ t.description }}:</strong> {{ t.systems }}</div>
+          }
+        </small>
       </div>
 
       <div class="col-12">

--- a/gebo.ui/projects/gebo-ai-admin-ui/src/lib/admin-ui/entity-editors/gebo-ai-webdav-client-admin/gebo-ai-webdav-system-fast.component.html
+++ b/gebo.ui/projects/gebo-ai-admin-ui/src/lib/admin-ui/entity-editors/gebo-ai-webdav-client-admin/gebo-ai-webdav-system-fast.component.html
@@ -32,11 +32,13 @@
       </div>
 
       <div class="col-12">
-        <small class="geboAuthTypeSystemsLegend">
-          @for (t of authTypes; track t.code) {
-            <div><strong>{{ t.description }}:</strong> {{ t.systems }}</div>
-          }
-        </small>
+        <p-fieldset id="AuthTypeSystemsLegendFieldset" gebo-ai-label legend="Authentication type legenda">
+          <small class="geboAuthTypeSystemsLegend">
+            @for (t of authTypes; track t.code) {
+              <div><strong>{{ t.description }}:</strong> {{ t.systems }}</div>
+            }
+          </small>
+        </p-fieldset>
       </div>
 
       <div class="col-12">

--- a/gebo.ui/projects/gebo-ai-admin-ui/src/lib/admin-ui/entity-editors/gebo-ai-webdav-client-admin/gebo-ai-webdav-system-fast.component.ts
+++ b/gebo.ui/projects/gebo-ai-admin-ui/src/lib/admin-ui/entity-editors/gebo-ai-webdav-client-admin/gebo-ai-webdav-system-fast.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Output } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup, Validators } from "@angular/forms";
 import { FastWebdavSystemInsertRequest, GWebdavContentManagementSystem, WebdavSystemsControllerService } from "@Gebo.ai/gebo-ai-rest-api";
 import { ToastMessageOptions } from "primeng/api";
@@ -27,12 +28,29 @@ export class GeboAIWebdavSystemFastComponent {
 
     userMessages: ToastMessageOptions[] = [];
 
-    authTypes: { code: GWebdavContentManagementSystem.WebdavAuthTypeEnum, description: string }[] = [
-        { code: "NONE", description: "No authentication" },
-        { code: "BASIC", description: "Basic (username + password)" },
-        { code: "DIGEST", description: "Digest" },
-        { code: "NTLM", description: "NTLM (Windows)" },
-        { code: "BEARER_TOKEN", description: "Bearer token" }
+    // "systems" lists known commercial/open-source WebDAV servers observed to use this
+    // authentication method, to help the admin pick the right one for their remote system.
+    authTypes: { code: GWebdavContentManagementSystem.WebdavAuthTypeEnum, description: string, systems: string }[] = [
+        {
+            code: "NONE", description: "No authentication",
+            systems: "Public/anonymous WebDAV shares (e.g. Nextcloud/ownCloud public links, an Apache mod_dav or nginx-dav mount with no auth configured)"
+        },
+        {
+            code: "BASIC", description: "Basic (username + password)",
+            systems: "Nextcloud / ownCloud classic (use an app password when 2FA or SSO is enabled), Seafile / SeafDAV (HTTPS only; account password or a dedicated WebDAV secret), Pydio Cells (username + password, or username + Personal Access Token as the password), ONLYOFFICE Workspace (portal login), Synology DSM WebDAV Server, generic Apache mod_dav / nginx WebDAV"
+        },
+        {
+            code: "DIGEST", description: "Digest",
+            systems: "Synology DSM WebDAV Server (selectable in DSM's WebDAV Server package), Apache mod_dav / mod_dav_svn, IIS WebDAV Publishing"
+        },
+        {
+            code: "NTLM", description: "NTLM (Windows)",
+            systems: "IIS WebDAV Publishing on Windows Server and other Windows-integrated-auth WebDAV shares"
+        },
+        {
+            code: "BEARER_TOKEN", description: "Bearer token",
+            systems: "OpenCloud / ownCloud Infinite Scale (oCIS) — Basic auth is disabled by default, so an OIDC/OAuth2 access token is required; Nextcloud/ownCloud classic when configured with the user_oidc app"
+        }
     ];
 
     public currentAuthType?: GWebdavContentManagementSystem.WebdavAuthTypeEnum = "BASIC";
@@ -41,7 +59,43 @@ export class GeboAIWebdavSystemFastComponent {
     @Output() cancelAction: EventEmitter<boolean> = new EventEmitter();
 
     constructor(private webdavSystemsService: WebdavSystemsControllerService) {
+        this.formGroup.controls["authType"].valueChanges
+            .pipe(takeUntilDestroyed())
+            .subscribe((type) => this.applyRequiredValidators(type));
         this.formGroup.controls["authType"].setValue(this.currentAuthType);
+    }
+
+    // username+password and token are only required for the auth types that actually
+    // use them; [required] on the field markup is a display-only asterisk, so the real
+    // Validators.required must be toggled here whenever authType changes, or a field
+    // left empty for an inapplicable auth type would still pass validation.
+    private applyRequiredValidators(type?: GWebdavContentManagementSystem.WebdavAuthTypeEnum): void {
+        const username = this.formGroup.controls["username"];
+        const password = this.formGroup.controls["password"];
+        const token = this.formGroup.controls["token"];
+
+        switch (type) {
+            case "BASIC":
+            case "DIGEST":
+            case "NTLM":
+                username.setValidators([Validators.required]);
+                password.setValidators([Validators.required]);
+                token.clearValidators();
+                break;
+            case "BEARER_TOKEN":
+                username.clearValidators();
+                password.clearValidators();
+                token.setValidators([Validators.required]);
+                break;
+            default:
+                username.clearValidators();
+                password.clearValidators();
+                token.clearValidators();
+                break;
+        }
+        username.updateValueAndValidity();
+        password.updateValueAndValidity();
+        token.updateValueAndValidity();
     }
 
     get showCredentials(): boolean {


### PR DESCRIPTION
## Summary
- `WebdavSystemsController.fastWebdavConfig`: when the connection test fails after a credential secret was already stored, the secret is now deleted immediately instead of being left orphaned/unreferenced. Same cleanup applied if `persistentObjectManager.insert` itself throws after a successful test. Error message now includes the actual exception via `GUserMessage.errorMessage(String, Throwable)`.
- `gebo-ai-webdav-system-fast.component`: replaced the static single-line help text (which turned out to be non-reactive due to `gebo-ai-field`'s one-time-translation lock on `help`) with an always-visible legend listing known commercial/open-source WebDAV servers per authentication method (Nextcloud/ownCloud, Seafile/SeafDAV, Pydio Cells, ONLYOFFICE Workspace, Synology DSM, OpenCloud/oCIS, IIS, Apache mod_dav, etc.), wrapped in a `p-fieldset` (`legend="Authentication type legenda"`, `gebo-ai-label`) to match the pattern used elsewhere in this admin UI.
- Same component: username/password/token are now marked `Validators.required` dynamically based on the selected auth type (via `authType.valueChanges`), instead of relying only on the display-only `[required]` template attribute — previously a BASIC-auth config could pass form validation with empty credentials since the FormControls had no real validators.
- Unrelated: `dockers/lib-multiplatform-images.sh` had `VERSION` hardcoded to `1.0.2.2`, already stale against the actual project version. Now reads it from the root `pom.xml` header.

## Test plan
- [x] `mvn -f gebo.systems.parent/gebo.webdav-cms.handler/pom.xml compile -o` — compiles clean
- [x] `npm run build-libs` (all four gebo.ui libraries, dependency order) — compiles clean
- [x] Rebuilt and ran the monolith (`angular-ui,swagger-on` profiles), verified in-browser via the "Setup company WebDAV systems" screen:
  - Legend renders inside a fieldset for all 5 auth types and stays visible regardless of selection
  - Switching auth type correctly toggles which fields are required (Create button enables/disables accordingly — verified NONE needs no credentials, BASIC needs username+password, BEARER_TOKEN needs only the token)
  - Submitted a config with an unreachable host: got a clean "Cannot connect to WebDAV server ... No such host is known" error, and confirmed no orphaned system row was left in the systems list afterward