### PR TITLE
fix: make version bumps reach the docker scripts and microservices compose

### DIFF
--- a/change-version.sh
+++ b/change-version.sh
@@ -25,6 +25,7 @@ echo "Changing from version $1 to $2"
 find . -name pom.xml | xargs sed -i s/"$1"/"$2"/ 
 sed -i s/"$1"/"$2"/ dockers/gebo.ai/Dockerfile
 sed -i s/"$1"/"$2"/ dockers/gebo.ai/create-image.bat
+sed -i s/"$1"/"$2"/ dockers/gebo.ai/*.sh
 sed -i s/"$1"/"$2"/ dockers/easyinstall.gebo.ai/Dockerfile
 sed -i s/"$1"/"$2"/ dockers/easyinstall.gebo.ai/create-image.bat
 sed -i s/"$1"/"$2"/ dockers/easyinstall.gebo.ai/*.sh
@@ -42,7 +43,7 @@ find ./gebo.api.clients/gebo.microservices.clients.parent -maxdepth 4 -path "*/p
 find ./gebo.api.clients/gebo.microservices.clients.parent -maxdepth 4 -path "*/projects/*/package.json" | xargs git stage
 sed -i s/"$1"/"$2"/ run.bat
 git stage run.bat 
-git stage dockers/gebo.ai/Dockerfile dockers/gebo.ai/create-image.bat
+git stage dockers/gebo.ai/Dockerfile dockers/gebo.ai/create-image.bat dockers/gebo.ai/*.sh
 git stage dockers/easyinstall.gebo.ai/Dockerfile dockers/easyinstall.gebo.ai/create-image.bat dockers/easyinstall.gebo.ai/*.sh
 git commit -m"Changed version from $1 to $2"
 

--- a/change-version.sh
+++ b/change-version.sh
@@ -29,6 +29,12 @@ sed -i s/"$1"/"$2"/ dockers/gebo.ai/*.sh
 sed -i s/"$1"/"$2"/ dockers/easyinstall.gebo.ai/Dockerfile
 sed -i s/"$1"/"$2"/ dockers/easyinstall.gebo.ai/create-image.bat
 sed -i s/"$1"/"$2"/ dockers/easyinstall.gebo.ai/*.sh
+# Microservices stack: .env pins the image tag compose resolves for every
+# geboai/*.gebo.ai service, and the compose file repeats it as the per-service
+# fallback - both must track the bump or the stack silently runs the previous
+# release's images.
+sed -i s/"$1"/"$2"/ dockers/gebo.microservices/.env
+sed -i s/"$1"/"$2"/ dockers/gebo.microservices/docker-compose.yml
 
 find . -name pom.xml | xargs git stage 
 sed -i s/"$1"/"$2"/ ./gebo.ui/package.json
@@ -45,5 +51,6 @@ sed -i s/"$1"/"$2"/ run.bat
 git stage run.bat 
 git stage dockers/gebo.ai/Dockerfile dockers/gebo.ai/create-image.bat dockers/gebo.ai/*.sh
 git stage dockers/easyinstall.gebo.ai/Dockerfile dockers/easyinstall.gebo.ai/create-image.bat dockers/easyinstall.gebo.ai/*.sh
+git stage dockers/gebo.microservices/.env dockers/gebo.microservices/docker-compose.yml
 git commit -m"Changed version from $1 to $2"
 

--- a/dockers/gebo.ai/create-image.sh
+++ b/dockers/gebo.ai/create-image.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 REPO_ROOT="$(cd ../.. && pwd)"
-VERSION="1.0.2.1-SNAPSHOT"
+VERSION="1.0.2.3"
 JAR="$REPO_ROOT/gebo.apps.parent/gebo.ai.app/target/gebo.ai.app-${VERSION}-bootable.jar"
 SBOM="$REPO_ROOT/gebo.apps.parent/gebo.ai.app/target/classes/META-INF/sbom/application.cdx.json"
 

--- a/dockers/gebo.microservices/.env
+++ b/dockers/gebo.microservices/.env
@@ -1,3 +1,3 @@
 # Image tag used by docker-compose.yml for all geboai/*.gebo.ai microservice images.
 # Must match the Maven project version the `mvn -P docker package` build produced.
-GEBO_VERSION=1.0.2.2-SNAPSHOT
+GEBO_VERSION=1.0.2.3

--- a/dockers/gebo.microservices/docker-compose.yml
+++ b/dockers/gebo.microservices/docker-compose.yml
@@ -111,7 +111,7 @@ services:
 
   # ---------------- Service registry ----------------
   eureka:
-    image: geboai/eureka.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/eureka.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     restart: unless-stopped
     ports:
       - "13017:13017"             # Eureka dashboard / registry
@@ -119,7 +119,7 @@ services:
 
   # ---------------- API gateway (the edge: Angular UI + aggregated API) --------
   gateway:
-    image: geboai/gateway.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/gateway.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     restart: unless-stopped
     depends_on: [eureka]
     environment:
@@ -192,7 +192,7 @@ services:
   # admin API is reachable from the edge.
   heimdall:
     <<: *microservice
-    image: geboai/heimdall.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/heimdall.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13018:13018"
 
@@ -203,34 +203,34 @@ services:
   # gebo.microservices.clients.parent point their <swagger.file> at.
   brain:
     <<: *microservice
-    image: geboai/brain.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/brain.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     depends_on: [eureka, rabbit, mongo, qdrant]
     ports:
       - "13001:13001"
 
   vectorizator:
     <<: *microservice
-    image: geboai/vectorizator.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/vectorizator.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     depends_on: [eureka, rabbit, mongo, qdrant]
     ports:
       - "13002:13002"
 
   graphicator:
     <<: *microservice
-    image: geboai/graphicator.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/graphicator.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     depends_on: [eureka, rabbit, mongo, neo4j]
     ports:
       - "13003:13003"
 
   chunker:
     <<: *microservice
-    image: geboai/chunker.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/chunker.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13004:13004"
 
   fulltextor:
     <<: *microservice
-    image: geboai/fulltextor.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/fulltextor.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     depends_on: [eureka, rabbit, mongo, opensearch]
     ports:
       - "13016:13016"
@@ -238,12 +238,12 @@ services:
   # ---------------- Content-handler microservices ----------------
   git:
     <<: *microservice
-    image: geboai/git.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/git.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13005:13005"
   filesystem:
     <<: *microservice
-    image: geboai/filesystem.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/filesystem.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     environment:
       <<: *microservice-env
       # Off by default (GeboAiFilesystemsConfig) since it lets an admin point a
@@ -265,57 +265,57 @@ services:
       - "13006:13006"
   uploads:
     <<: *microservice
-    image: geboai/uploads.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/uploads.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13007:13007"
   userspace:
     <<: *microservice
-    image: geboai/userspace.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/userspace.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13008:13008"
   sharepoint:
     <<: *microservice
-    image: geboai/sharepoint.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/sharepoint.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13009:13009"
   confluence:
     <<: *microservice
-    image: geboai/confluence.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/confluence.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13010:13010"
   jira:
     <<: *microservice
-    image: geboai/jira.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/jira.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13011:13011"
   aws-s3:
     <<: *microservice
-    image: geboai/aws-s3.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/aws-s3.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13012:13012"
   googledrive:
     <<: *microservice
-    image: geboai/googledrive.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/googledrive.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13013:13013"
   mcpclient:
     <<: *microservice
-    image: geboai/mcpclient.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/mcpclient.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13014:13014"
   webdav:
     <<: *microservice
-    image: geboai/webdav.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/webdav.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13020:13020"
   integration:
     <<: *microservice
-    image: geboai/integration.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/integration.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13015:13015"
   tyr:
     <<: *microservice
-    image: geboai/tyr.gebo.ai:${GEBO_VERSION:-1.0.2.0-SNAPSHOT}
+    image: geboai/tyr.gebo.ai:${GEBO_VERSION:-1.0.2.3}
     ports:
       - "13019:13019"
 

--- a/gebo.ui/package-lock.json
+++ b/gebo.ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gebo-ai-ui",
-  "version": "1.0.2.3-SNAPSHOT",
+  "version": "1.0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gebo-ai-ui",
-      "version": "1.0.2.3-SNAPSHOT",
+      "version": "1.0.2.3",
       "dependencies": {
         "@angular/animations": "^21.2.18",
         "@angular/cdk": "^21.2.14",


### PR DESCRIPTION
## Summary

`change-version.sh` is the single mechanism that propagates a version bump out of `pom.xml` into the non-Maven build assets. Three of those assets were never on its list, so they silently kept whatever version someone last typed by hand. Found while cutting the 1.0.2.3 images.

## What was broken

| File | Was | Effect |
|---|---|---|
| `dockers/gebo.ai/create-image.sh` | `1.0.2.1-SNAPSHOT` | Script failed outright — pointed at a bootable jar that no longer exists |
| `dockers/gebo.microservices/.env` | `1.0.2.2-SNAPSHOT` | Stack silently ran the previous release's images |
| `docker-compose.yml` (21 fallbacks) | `1.0.2.0-SNAPSHOT` | Same, when `GEBO_VERSION` is unset |

The `gebo.ai` case is the clearest miss: `change-version.sh` had a `dockers/easyinstall.gebo.ai/*.sh` line but no `dockers/gebo.ai/*.sh` equivalent, so `create-image.sh` drifted while its `create-image.bat` sibling tracked every bump correctly.

The `.env` comment already stated the contract it was violating: *"Must match the Maven project version the `mvn -P docker package` build produced."*

## Changes

- Correct all three files to `1.0.2.3`
- Add `dockers/gebo.ai/*.sh`, `dockers/gebo.microservices/.env` and `docker-compose.yml` to both the sed propagation and the `git stage` list in `change-version.sh`, so they follow future bumps
- Pick up `gebo.ui/package-lock.json` (`1.0.2.3-SNAPSHOT` → `1.0.2.3`), rewritten by the `angular-ui` build — `change-version.sh` updates `package.json` files but not their lock files

## Verification

- `docker compose config -q` passes; all 21 services resolve to `geboai/*:1.0.2.3` with no `GEBO_VERSION` override
- Dry-run of a `1.0.2.3 → 1.0.2.4` bump correctly rewrites `.env` and all 21 fallbacks
- `dockers/gebo.ai/create-image.sh` was used to build the image that produced the tested `geboai/gebo.ai:1.0.2.3` — stack came up clean, 0 errors, UI footer reported 1.0.2.3

## Not addressed

`ArchitecturalComposeTest.java:121` defaults to `gebo.image.version=1.0.2.2-SNAPSHOT` — same drift, left out as it's test code and part of a separate microservices cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eVfcdhR7SPoUNtXBWZRdj