### PR TITLE
bouncycastle: align all bc* artifacts via parent dependencyManagement

### DIFF
--- a/gebo.architecture.parent/gebo.architecture.crypting/pom.xml
+++ b/gebo.architecture.parent/gebo.architecture.crypting/pom.xml
@@ -19,19 +19,16 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.84</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk18on -->
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk18on</artifactId>
-			<version>1.84</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpg-jdk18on -->
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpg-jdk18on</artifactId>
-			<version>1.84</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/gebo.architecture.parent/gebo.secrets.impl/pom.xml
+++ b/gebo.architecture.parent/gebo.secrets.impl/pom.xml
@@ -61,13 +61,11 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.78.1</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk18on -->
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk18on</artifactId>
-			<version>1.78.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/gebo.architecture.parent/gebo.secrets.services/pom.xml
+++ b/gebo.architecture.parent/gebo.secrets.services/pom.xml
@@ -51,13 +51,11 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.78.1</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk18on -->
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk18on</artifactId>
-			<version>1.78.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,12 @@
 		<maven-source-plugin.version>3.3.0</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
 		<version.swagger.codegen>2.4.44</version.swagger.codegen>
+		<!-- Bouncy Castle expects its bc* artifacts to move as a matched set; see the
+		     dependencyManagement entries below. bcprov ships an extra patch release
+		     (1.85.2) that the other artifacts don't, so the provider carries its own
+		     property — that pairing is the combination BC itself publishes. -->
+		<bouncycastle.version>1.85</bouncycastle.version>
+		<bouncycastle.prov.version>1.85.2</bouncycastle.prov.version>
 		<maven.compiler.release></maven.compiler.release>
 	</properties>
 	<modules>
@@ -201,6 +207,38 @@
 				<groupId>com.squareup.okio</groupId>
 				<artifactId>okio-jvm</artifactId>
 				<version>3.16.4</version>
+			</dependency>
+			<!-- gebo.architecture.crypting, gebo.secrets.services and gebo.secrets.impl
+			     each hardcoded their own bcprov/bcpkix version (1.84 vs 1.78.1), so
+			     nearest-wins mediation put bcprov 1.78.1 on the assembled app's runtime
+			     classpath next to bcpkix 1.81.1 and bcpg 1.84 — an unsupported mix, and
+			     an outdated provider the module poms gave no hint of. Managing all five
+			     bc* artifacts here pins the transitive ones (bcutil, bcjmail) too, so
+			     the set can only move together. -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>${bouncycastle.prov.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpg-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcutil-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcjmail-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
## Problem

`gebo.architecture.crypting` hardcoded Bouncy Castle `1.84`, while `gebo.secrets.services` and `gebo.secrets.impl` hardcoded `1.78.1`. Maven's nearest-wins mediation resolved the conflict in favour of **`bcprov` 1.78.1** on the assembled app's runtime classpath — an outdated provider carrying the reported CVEs.

Two things made this hard to spot:

- No single module pom showed the shipped version. `crypting` says 1.84; the app ships 1.78.1.
- The result was **version-skewed**: `bcprov` 1.78.1 + `bcpkix` 1.81.1 + `bcpg` 1.84. Bouncy Castle expects its `bc*` artifacts to move as a matched set, so this is unsupported independently of any CVE.

Confirmed against the SBOM emitted by the production build, not inferred from the poms.

## Change

Manage all five `bc*` artifacts in the root `ai.gebo.parent` pom and drop the hardcoded versions from the three modules. Central management also pins `bcutil` and `bcjmail`, which arrive transitively and were skewed at 1.84 and 1.81 — `dependencyManagement` is what controls transitive versions, so they could not have been fixed module-side.

`bcprov` ships an extra patch release the others do not, so it carries its own property; `1.85.2` + `1.85` is the combination BC itself publishes.

## Resolved versions on `gebo.ai.app`

| Artifact | Before | After |
|---|---|---|
| `bcprov-jdk18on` | 1.78.1 | **1.85.2** |
| `bcpkix-jdk18on` | 1.81.1 | 1.85 |
| `bcjmail-jdk18on` | 1.81 | 1.85 |
| `bcpg-jdk18on` | 1.84 | 1.85 |
| `bcutil-jdk18on` | 1.84 | 1.85 |

## Verification

- `mvn dependency:tree -Dincludes='org.bouncycastle:*'` on `gebo.ai.app` — aligned set, no 1.78.1 anywhere in the tree.
- Full production build (`compile-prod.sh`) succeeds; the regenerated SBOM shows the aligned set in the shipped bootable jar.

## Not covered here

- **Tests have not been run.** `compile-prod.sh` uses `-DskipTests`, and this is a seven-release provider jump across code doing signing, PGP and secrets handling — the areas most likely to surface a behavioural change. A `compile-testall.sh` run should gate the merge.
- **Specific CVE IDs are not verified.** The upgrade is justified by the version gap and the unsupported mix; nobody has checked which advisories 1.85.2 actually closes.