### PR TITLE
dockers: derive image version from root pom.xml, not a hardcoded literal

### DIFF
--- a/dockers/build-sbom-images.bat
+++ b/dockers/build-sbom-images.bat
@@ -21,7 +21,27 @@ REM --------------------------------------------------------------------------
 setlocal enabledelayedexpansion
 
 set "REPO_ROOT=%~dp0.."
-set "VERSION=1.0.2.1-SNAPSHOT"
+REM Read the project's own <version> from the root pom.xml, taking the first
+REM <version> and stopping at <parent> so we don't pick up spring-boot-starter-
+REM parent's version instead. Mirrors lib-multiplatform-images.sh / build-sbom-
+REM images.sh — keeps this aligned with whatever the actual build produces
+REM instead of a hardcoded literal that goes stale as the version moves on.
+set "VERSION="
+for /f "usebackq delims=" %%L in ("%REPO_ROOT%\pom.xml") do (
+  if not defined VERSION (
+    set "LINE=%%L"
+    echo(!LINE! | findstr /c:"<parent>" >nul && goto :version_done
+    echo(!LINE! | findstr /c:"<version>" >nul && (
+      set "VERSION=!LINE:*<version>=!"
+      set "VERSION=!VERSION:</version>=!"
+    )
+  )
+)
+:version_done
+if not defined VERSION (
+  echo ERROR: Could not read project version from %REPO_ROOT%\pom.xml
+  exit /b 1
+)
 set "JAR=%REPO_ROOT%\gebo.apps.parent\gebo.ai.app\target\gebo.ai.app-%VERSION%-bootable.jar"
 set "SBOM=%REPO_ROOT%\gebo.apps.parent\gebo.ai.app\target\classes\META-INF\sbom\application.cdx.json"
 

--- a/dockers/build-sbom-images.sh
+++ b/dockers/build-sbom-images.sh
@@ -22,7 +22,15 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-VERSION="1.0.2.1-SNAPSHOT"
+# Read the project's own <version> from the root pom.xml header, stopping at
+# <parent> so we don't accidentally match spring-boot-starter-parent's version
+# instead. Keeps this script aligned with whatever the actual build produces —
+# this was hardcoded, and went stale as the project version moved on.
+VERSION="$(sed -n '/<parent>/q;p' "$REPO_ROOT/pom.xml" | grep -oP '(?<=<version>)[^<]+(?=</version>)' | head -1)"
+if [ -z "$VERSION" ]; then
+  echo "ERROR: Could not read project version from $REPO_ROOT/pom.xml"
+  exit 1
+fi
 JAR="$REPO_ROOT/gebo.apps.parent/gebo.ai.app/target/gebo.ai.app-${VERSION}-bootable.jar"
 SBOM="$REPO_ROOT/gebo.apps.parent/gebo.ai.app/target/classes/META-INF/sbom/application.cdx.json"
 

--- a/dockers/push-sbom-images.bat
+++ b/dockers/push-sbom-images.bat
@@ -23,7 +23,28 @@ REM --------------------------------------------------------------------------
 setlocal enabledelayedexpansion
 
 set "REPO_ROOT=%~dp0.."
-set "VERSION=1.0.2.1-SNAPSHOT"
+REM Read the project's own <version> from the root pom.xml, taking the first
+REM <version> and stopping at <parent> so we don't pick up spring-boot-starter-
+REM parent's version instead. Mirrors lib-multiplatform-images.sh — keeps this
+REM aligned with whatever the actual build produces instead of a hardcoded
+REM literal that goes stale. This script pushes, so a stale tag here would
+REM publish under the wrong version, not just fail locally.
+set "VERSION="
+for /f "usebackq delims=" %%L in ("%REPO_ROOT%\pom.xml") do (
+  if not defined VERSION (
+    set "LINE=%%L"
+    echo(!LINE! | findstr /c:"<parent>" >nul && goto :version_done
+    echo(!LINE! | findstr /c:"<version>" >nul && (
+      set "VERSION=!LINE:*<version>=!"
+      set "VERSION=!VERSION:</version>=!"
+    )
+  )
+)
+:version_done
+if not defined VERSION (
+  echo ERROR: Could not read project version from %REPO_ROOT%\pom.xml
+  exit /b 1
+)
 set "PLATFORMS=linux/amd64,linux/arm64"
 set "JAR=%REPO_ROOT%\gebo.apps.parent\gebo.ai.app\target\gebo.ai.app-%VERSION%-bootable.jar"
 set "SBOM=%REPO_ROOT%\gebo.apps.parent\gebo.ai.app\target\classes\META-INF\sbom\application.cdx.json"


### PR DESCRIPTION
## Problem

`dockers/build-sbom-images.sh`, `dockers/build-sbom-images.bat` and `dockers/push-sbom-images.bat` each hardcoded `VERSION=1.0.2.1-SNAPSHOT` — three releases behind the project's actual `1.0.2.4-SNAPSHOT`.

- The two local build scripts fail their own `check_artifacts`: the versioned bootable-jar name (`gebo.ai.app-1.0.2.1-SNAPSHOT-bootable.jar`) no longer matches what the build produces.
- `push-sbom-images.bat` is worse — it pushes to Docker Hub with `--sbom=true`, so a stale literal tags the publish with the **wrong version** rather than just failing locally.

The multiplatform scripts (`lib-multiplatform-images.sh`, used by today's production publish) already derive the version from `pom.xml`; these three sbom scripts were the ones left hardcoding it.

## Change

Read the project's own `<version>` from the root `pom.xml`, taking the first `<version>` and stopping at `<parent>` so `spring-boot-starter-parent`'s `4.1.0` can't be matched instead. This mirrors the existing shell parse in `lib-multiplatform-images.sh`.

- **`.sh`**: same `sed -n '/<parent>/q;p' | grep -oP` one-liner already proven in the multiplatform lib, plus an empty-result guard.
- **`.bat`**: batch has no `grep -oP`, so a `for /f` reads the pom top-down, matches the first `<version>` via `findstr`, stops at `<parent>`, and extracts the value with delayed-expansion substring strips (`!LINE:*<version>=!` then `!VERSION:</version>=!`) — robust to indentation.

## Verification

- `.sh`: syntax-checked (`bash -n`); derives `1.0.2.4-SNAPSHOT` and the resulting jar path resolves to the real bootable jar.
- `.bat`: parse logic simulated against the real `pom.xml` — yields `1.0.2.4-SNAPSHOT` with tags and indentation stripped. Not executed (no Windows shell available here).

No functional change to what the scripts build or push beyond using the correct version string.