### PR TITLE
deps: bump netty to 4.2.16.Final and spring-retry to 2.0.13 (CVE fixes)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,17 @@
 		<apache-poi.version>5.5.1</apache-poi.version>
 		<spring.ai.version>2.0.0</spring.ai.version>
 		<springdoc.version>3.0.3</springdoc.version>
-		<spring-retry.version>2.0.12</spring-retry.version>
+		<!-- 2.0.12 is affected by CVE-2026-41710; 2.0.13 is the fix. This property
+		     is consumed by gebo.ranker.api and gebo.architecture.llms.abstraction.layer. -->
+		<spring-retry.version>2.0.13</spring-retry.version>
+		<!-- Override Spring Boot 4.1.0's managed netty.version (4.2.15.Final).
+		     spring-boot-dependencies imports io.netty:netty-bom:${netty.version},
+		     so bumping this property re-resolves the whole netty BOM. 4.2.15.Final
+		     is affected by a cluster of netty-codec-* advisories (http, http2,
+		     http3, dns, compression — CVE-2026-55831/-55833/-56745/-56746/-56816/
+		     -56819/-59898/-59899/-59900/-59901/-59921/-73508); 4.2.16.Final fixes
+		     all of them. netty is pulled in transitively; we declare none directly. -->
+		<netty.version>4.2.16.Final</netty.version>
 		<maven-source-plugin.version>3.3.0</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
 		<version.swagger.codegen>2.4.44</version.swagger.codegen>


### PR DESCRIPTION
## Context

An OSV.dev scan of the production build's CycloneDX SBOM (665 components) flagged 15 packages. This PR closes the two most actionable clusters — **13 of the 25 advisories** — both fixable by a single property each. (Bouncy Castle, the original trigger, is already clean via #150.)

## Fixes

### netty 4.2.15.Final → 4.2.16.Final — 12 advisories
| Module | CVEs |
|---|---|
| `netty-codec-http` | CVE-2026-55831, -55833, -56745, -56746, -59898, -59899, -59921 |
| `netty-codec-http2` | CVE-2026-56819, -59900 |
| `netty-codec-http3` | CVE-2026-56816 |
| `netty-codec-compression` | CVE-2026-59901 |
| `netty-codec-dns` | CVE-2026-73508 |

netty is **transitive only** — no pom declares it directly. `spring-boot-dependencies:4.1.0` imports `io.netty:netty-bom:${netty.version}`, so overriding the `netty.version` property in the root pom re-resolves the entire netty BOM in one move.

### spring-retry 2.0.12 → 2.0.13 — CVE-2026-41710
`spring-retry.version` was already a property in the root pom, consumed by `gebo.ranker.api` and `gebo.architecture.llms.abstraction.layer`.

## Verification

- `mvn dependency:tree` on `gebo.ai.app`: every `io.netty:*` artifact resolves to `4.2.16.Final` (zero `4.2.15.Final` remaining); `spring-retry` to `2.0.13`. BUILD SUCCESS.
- Re-queried OSV for all affected coordinates at the new versions — **all report clean**.
- `netty-tcnative-*` stay at `2.0.78.Final` (independently-versioned native bindings, not covered by `netty.version`, not in any advisory).

## Not included here

The scan flagged 6 further packages, deliberately left out of this PR to keep it to the clean single-property fixes:

| Package | Fix | Notes |
|---|---|---|
| `microsoft-kiota-abstractions` 1.8.10 | 1.9.1 | HIGH (CVE-2026-44503) |
| `httpcore5` / `httpcore5-h2` 5.4.2 | 5.4.3 | HIGH (CVE-2026-54399 / -54428) |
| `httpclient5` 5.6.1 | 5.6.3 | MODERATE |
| `jackson-databind` 2.21.4 & 3.1.4 | 2.21.5 / 3.1.5 | two major lines carried |
| `junrar` 7.5.5 | 7.5.10 | MODERATE |
| `log4j-api` 2.25.4 | 2.25.5 | MODERATE |
| `jsoup` 1.18.1 | 1.23.1 | MODERATE |

Most of these are Spring-Boot-managed and need per-package property overrides + resolution checks; worth a follow-up.

## Caveat

Not yet built end-to-end or tested — a netty minor bump under a fresh Spring Boot 4.1.0 is low-risk, but `compile-testall.sh` should gate the merge, same as the sibling dependency PRs.