### PR TITLE
zero-cve-policy: OWASP dependency-check sui 22 pom con bootable jar

### DIFF
--- a/gebo.apps.parent/gebo.ai.app/pom.xml
+++ b/gebo.apps.parent/gebo.ai.app/pom.xml
@@ -8,6 +8,13 @@
 		<version>1.0.2.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>gebo.ai.app</artifactId>
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>ai.gebo.apps</groupId>
@@ -599,6 +606,15 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
+		</profile>
 	</profiles>
 	<build>
 		<plugins>
@@ -620,6 +636,32 @@
 			</plugin>
 
 
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/aws-s3.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/aws-s3.gebo.ai/pom.xml
@@ -15,6 +15,13 @@
 	  Eureka discovery client; gebo.aws-s3.content.handler is the hosted content
 	  system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- Does not own the ACL store either: IAclAliasesDao is a locally-cached REST
 		     client onto heimdall. -->
@@ -58,6 +65,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar (classifier bootable). -->
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
@@ -133,6 +170,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/brain.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/brain.gebo.ai/pom.xml
@@ -9,6 +9,13 @@
 	</parent>
 	<artifactId>brain.gebo.ai</artifactId>
 
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- The Spring Security filter chain + LOCAL_JWT provider (GeboAISecurityConfig,
 		     LocalJwtTokenProvider, GSecurityServiceImpl, AclGrantedAccessorServiceImpl).
@@ -151,6 +158,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
 		bootable+swagger). -->
@@ -227,6 +264,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/chunker.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/chunker.gebo.ai/pom.xml
@@ -8,6 +8,13 @@
 		<version>1.0.2.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>chunker.gebo.ai</artifactId>
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- Does not own the ACL store either: IAclAliasesDao is a locally-cached REST
 		     client onto heimdall. -->
@@ -73,6 +80,36 @@
 	  generated client stubs had no spec to read. Both profiles below bring it in
 	  line with every other service.
 	-->
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
 		bootable+swagger). Off by default: production ships no API console. It is
@@ -148,6 +185,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/confluence.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/confluence.gebo.ai/pom.xml
@@ -15,6 +15,13 @@
 	  Eureka discovery client; gebo.atlassian.confluence.handler is the hosted content
 	  system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- Does not own the ACL store either: IAclAliasesDao is a locally-cached REST
 		     client onto heimdall. -->
@@ -58,6 +65,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar (classifier bootable). -->
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
@@ -133,6 +170,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/eureka.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/eureka.gebo.ai/pom.xml
@@ -15,6 +15,13 @@
 	  client-side load balancing and the gateway's lb:// routes can resolve live
 	  instances. Runs standalone (does not register with / fetch from itself).
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- Netflix Eureka server (this artifact already includes the eureka client
 		     inherited from the parent, which is why the server runs standalone via
@@ -25,6 +32,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar (classifier bootable). -->
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
@@ -102,6 +139,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/filesystem.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/filesystem.gebo.ai/pom.xml
@@ -15,6 +15,13 @@
 	  (inherited) Eureka discovery client; gebo.filesystem.content.handler is the
 	  hosted content system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- The Spring Security filter chain + LOCAL_JWT provider. Deliberately WITHOUT
 		     gebo.security.directory.mongo: gebo.microservices.security.client (already
@@ -37,6 +44,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar (classifier bootable). -->
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
@@ -112,6 +149,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/fulltextor.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/fulltextor.gebo.ai/pom.xml
@@ -15,6 +15,13 @@
 	  Eureka discovery client; gebo.ragsystem.content.fulltext.processor is the hosted
 	  full-text indexing/search system (OpenSearch-backed).
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- Does not own the ACL store either: IAclAliasesDao is a locally-cached REST
 		     client onto heimdall. -->
@@ -60,6 +67,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier bootable+swagger). -->
 		<profile>
@@ -131,6 +168,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/gateway.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/gateway.gebo.ai/pom.xml
@@ -9,6 +9,13 @@
 	</parent>
 	<artifactId>gateway.gebo.ai</artifactId>
 
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- Spring Cloud Gateway (reactive / WebFlux server) -->
 		<dependency>
@@ -61,6 +68,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!--
 		  Swagger / OpenAPI UI. DISABLED by default, and deliberately so: a
@@ -498,6 +535,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/git.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/git.gebo.ai/pom.xml
@@ -14,6 +14,13 @@
 	  microservices environment, RabbitMQ bridge, shared topology and (inherited)
 	  Eureka discovery client; gebo.git.content.handler is the hosted content system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>ai.gebo.microservices.architecture</groupId>
@@ -27,6 +34,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
 		bootable+swagger). Off by default: production ships no API console. It is
@@ -102,6 +139,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/googledrive.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/googledrive.gebo.ai/pom.xml
@@ -15,6 +15,13 @@
 	  (inherited) Eureka discovery client; gebo.googleworkspace.handlers is the hosted
 	  content system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>ai.gebo.microservices.architecture</groupId>
@@ -28,6 +35,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar (classifier bootable). -->
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
@@ -103,6 +140,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/graphicator.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/graphicator.gebo.ai/pom.xml
@@ -9,6 +9,13 @@
 	</parent>
 	<artifactId>graphicator.gebo.ai</artifactId>
 
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- Full LLMs microservice stack: LLM abstraction layer, microservices
 		     environment, RabbitMQ bridge, models-replication cache and shared
@@ -25,6 +32,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier bootable+swagger). -->
 		<profile>
@@ -96,6 +133,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/heimdall.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/heimdall.gebo.ai/pom.xml
@@ -22,6 +22,13 @@
 	  entry "heimdall_gebo_ai: AuthN/AuthZ, OAuth2 integration. Owns no messaging
 	  module (REST-only edge)".
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- The real IGeboSecretsAccessService (GeboSecretsAccessServiceImpl) + the
 		     existing ADMIN/UI api/admin/SecretsController. -->
@@ -128,6 +135,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
 		     bootable+swagger). Off by default: production ships no API console. It is
@@ -203,6 +240,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/integration.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/integration.gebo.ai/pom.xml
@@ -15,6 +15,13 @@
 	  (inherited) Eureka discovery client; gebo.integration.content.handler is the
 	  hosted content system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- Does not own the ACL store either: IAclAliasesDao is a locally-cached REST
 		     client onto heimdall. -->
@@ -58,6 +65,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar (classifier bootable). -->
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
@@ -133,6 +170,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/jira.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/jira.gebo.ai/pom.xml
@@ -15,6 +15,13 @@
 	  Eureka discovery client; gebo.atlassian.jira.handler is the hosted content
 	  system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- Does not own the ACL store either: IAclAliasesDao is a locally-cached REST
 		     client onto heimdall. -->
@@ -58,6 +65,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar (classifier bootable). -->
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
@@ -133,6 +170,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/mcpclient.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/mcpclient.gebo.ai/pom.xml
@@ -15,6 +15,13 @@
 	  Eureka discovery client; gebo.mcp-client.content.handler is the hosted content
 	  system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>ai.gebo.microservices.architecture</groupId>
@@ -28,6 +35,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar (classifier bootable). -->
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
@@ -103,6 +140,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/sharepoint.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/sharepoint.gebo.ai/pom.xml
@@ -14,6 +14,13 @@
 	  the microservices environment, RabbitMQ bridge, shared topology and (inherited)
 	  Eureka discovery client; gebo.sharepoint.handler is the hosted content system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>ai.gebo.microservices.architecture</groupId>
@@ -27,6 +34,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar (classifier bootable). -->
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
@@ -102,6 +139,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/tyr.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/tyr.gebo.ai/pom.xml
@@ -21,6 +21,13 @@
 	  bridge + topology + Eureka, no content-handler business logic) plus this
 	  one addition, so it stays minimal otherwise.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>ai.gebo.microservices.architecture</groupId>
@@ -91,6 +98,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
 		bootable+swagger). Off by default: production ships no API console. It is
@@ -166,6 +203,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/uploads.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/uploads.gebo.ai/pom.xml
@@ -15,6 +15,13 @@
 	  Eureka discovery client; gebo.uploads.content.handler is the hosted content
 	  system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>ai.gebo.microservices.architecture</groupId>
@@ -28,6 +35,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar (classifier bootable). -->
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
@@ -103,6 +140,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/userspace.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/userspace.gebo.ai/pom.xml
@@ -14,6 +14,13 @@
 	  the microservices environment, RabbitMQ bridge, shared topology and (inherited)
 	  Eureka discovery client; gebo.userspace.handler is the hosted content system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>ai.gebo.microservices.architecture</groupId>
@@ -27,6 +34,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar (classifier bootable). -->
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
@@ -102,6 +139,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/vectorizator.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/vectorizator.gebo.ai/pom.xml
@@ -9,6 +9,13 @@
 	</parent>
 	<artifactId>vectorizator.gebo.ai</artifactId>
 
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<!-- Full LLMs microservice stack: LLM abstraction layer, microservices
 		     environment, RabbitMQ bridge, models-replication cache and shared
@@ -33,6 +40,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier bootable+swagger). -->
 		<profile>
@@ -104,6 +141,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>

--- a/gebo.apps.parent/gebo.microservices.apps.parent/webdav.gebo.ai/pom.xml
+++ b/gebo.apps.parent/gebo.microservices.apps.parent/webdav.gebo.ai/pom.xml
@@ -14,6 +14,13 @@
 	  microservices environment, RabbitMQ bridge, shared topology and (inherited)
 	  Eureka discovery client; gebo.webdav-cms.handler is the hosted content system.
 	-->
+	<properties>
+		<dependency-check.version>12.2.2</dependency-check.version>
+
+		<!-- build ordinaria: non bloccare -->
+		<dependency-check.failBuildOnCVSS>11</dependency-check.failBuildOnCVSS>
+		<dependency-check.failOnError>false</dependency-check.failOnError>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>ai.gebo.microservices.architecture</groupId>
@@ -27,6 +34,36 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>${dependency-check.version}</version>
+				<!-- non eseguire questa execution nei singoli moduli -->
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>dependency-vulnerability-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoUpdate>true</autoUpdate>
+					<failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+					<failOnError>${dependency-check.failOnError}</failOnError>
+					<formats>
+						<format>HTML</format>
+						<format>JSON</format>
+					</formats>
+					<outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<!-- Bootable fat jar WITH the OpenAPI/Swagger UI (classifier
 		bootable+swagger). Off by default: production ships no API console. It is
@@ -102,6 +139,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>production</id>
+			<properties>
+				<!-- Critical -->
+				<dependency-check.failBuildOnCVSS>9.0</dependency-check.failBuildOnCVSS>
+				<!-- se lo scanner non funziona, produzione bloccata -->
+				<dependency-check.failOnError>true</dependency-check.failOnError>
+			</properties>
 		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
## Obiettivo

Aggiungere una policy zero-CVE: generare un report CVE in build ordinaria e **bloccare su CVE critiche nelle build di produzione**, su ogni artefatto deployabile.

## Cosa fa

Aggiunge `org.owasp:dependency-check-maven:12.2.2` (goal `aggregate`, fase `verify`) ai **22 pom che producono un bootable jar**: il monolite `gebo.ai.app` + le 21 microservice app sotto `gebo.microservices.apps.parent`.

- **Build ordinaria** → report HTML+JSON in `target/dependency-check/`, **non blocca** (`failBuildOnCVSS=11`, `failOnError=false`).
- **Build di produzione** (`-Pproduction`) → **blocca** su CVE critiche (`failBuildOnCVSS=9.0`) e se lo scanner fallisce (`failOnError=true`).

Soglie esposte come proprietà, sovrascritte dal profilo `production`; plugin con `inherited=false` (aggregate va eseguito una volta sul modulo deployabile).

## Verificato

- XML well-formed + modello Maven valido su tutti i 22 pom (`mvn validate` EXIT=0).
- `effective-pom` conferma **11/false** in ordinaria, **9.0/true** con `-Pproduction`.
- **Build complessivo `mvn clean verify -DskipTests`: BUILD SUCCESS** — dependency-check gira su `gebo.ai.app`, genera il report e non blocca (comportamento voluto).
- Con NVD API key: report reale prodotto (505 dip. scansionate, 42 vulnerabili).

## ⚠️ Note operative (prima di attivare il gate di produzione)

1. **Serve una NVD API key in CI.** Ogni build `verify`/`install` ora esegue dependency-check, che scarica il feed NVD. Senza key il download è pesantemente rate-limited (fallisce o è lentissimo); in ordinaria non blocca grazie a `failOnError=false`, ma va configurata `nvd.api.key` (via settings.xml/env segreta, **non** nel pom) per avere report affidabili.
2. **`-Pproduction` oggi bloccherebbe la build.** Lo scan NVD/CPE trova 33 CRITICAL, ma molti sono **falsi positivi da CPE-matching** (es. i nostri client `gebo.atlassian.*` abbinati alle CVE del server Confluence/Jira; `spring-boot-devtools` — usato in prod per `FileSystemWatcher` — abbinato a CVE-2022-31691 che riguarda l'estensione IDE "Spring Boot Tools", non la libreria). Prima di attivare `-Pproduction` in CI serve un **`dependency-check-suppression.xml`** per i falsi positivi. Follow-up separato.

Nessuna API key è committata in questa PR.